### PR TITLE
feat: add opt-in concurrency throttle for transformers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ src/
 ├── types.ts                  # OnlyPossiblyUndefined helper
 ├── typeHelper.ts             # InputOf, OutputOf, PropsOf, IncludesOf
 ├── index.ts                  # Entry: t7m
+├── semaphore.ts              # Async semaphore for concurrency control
 └── hono/
     ├── middleware.ts          # t7mMiddleware
     ├── augment.ts             # Hono Context type augmentation
@@ -122,6 +123,42 @@ await transformer.transform({ input: user })
 
 // Props type defined → props is REQUIRED
 await transformer.transform({ input: user, props: { db } })
+```
+
+### 9. `concurrency` only applies to `transformMany` / `_transformMany`
+
+- `concurrency` in constructor limits parallel items in batch methods only
+- `transform()` and `_transform()` (single item) are NOT throttled by `concurrency`
+- Per-include limits (`includesConcurrency`) apply to ALL transform methods
+- The semaphore is instance-level: shared across all concurrent calls on the same instance
+
+```typescript
+// concurrency: 5 limits transformMany to 5 parallel items
+// Does NOT limit concurrent transform() calls
+class MyTransformer extends AbstractTransformer<In, Out> {
+  constructor() {
+    super({ concurrency: 5 })
+  }
+
+  // Per-include limits apply everywhere (transform + transformMany)
+  includesConcurrency = {
+    posts: 3,
+  }
+}
+```
+
+### 10. `includesConcurrency` is a class property, not constructor config
+
+```typescript
+// ✅ CORRECT — class property (like includesMap)
+includesConcurrency = {
+  posts: 3,
+}
+
+// ❌ WRONG — not a constructor param
+constructor() {
+  super({ includesConcurrency: { posts: 3 } }) // Does not exist
+}
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -355,6 +355,93 @@ Concurrent calls with the same input don't even wait — they share a single in-
 | 10,000 cached primitive lookups | microseconds per lookup |
 | Cached vs uncached (1ms async op, 1,000 calls) | ~1ms cached vs ~1,000ms uncached |
 
+## Concurrency Control
+
+### The Problem
+
+`transformMany` processes all items in parallel via `Promise.all`, and each item's includes also run in parallel. This is great for speed, but when includes make external API calls (e.g., auth providers, third-party APIs), hundreds of concurrent requests can overwhelm rate limits or hit connection ceilings.
+
+### Item-Level Concurrency
+
+The `concurrency` constructor parameter limits how many items `transformMany` / `_transformMany` process in parallel:
+
+```typescript
+class CommentTransformer extends AbstractTransformer<Comment, PublicComment> {
+  constructor() {
+    super({ concurrency: 5 }) // Process at most 5 items at a time
+  }
+
+  // ...
+}
+
+// 100 comments — processed in batches of 5 instead of all at once
+await transformer.transformMany({ inputs: comments, includes: ['author'] })
+```
+
+This does **not** apply to `transform` / `_transform` (single item — nothing to throttle).
+
+### Per-Include Concurrency
+
+The `includesConcurrency` property limits how many times a specific include function can run concurrently across all items. Include keys not listed remain unlimited:
+
+```typescript
+class CommentTransformer extends AbstractTransformer<Comment, PublicComment> {
+  includesConcurrency = {
+    author: 3, // At most 3 concurrent author lookups across all items
+  }
+
+  includesMap = {
+    author: async (input: Comment) => {
+      const user = await auth.getUser(input.userId)
+      return { name: user.name }
+    },
+    tags: async (input: Comment) => {
+      // No limit — runs with full parallelism
+      return await db.getTagsForComment(input.id)
+    },
+  }
+}
+```
+
+The semaphore is shared across all calls on the same transformer instance, so even if multiple `transformMany` calls overlap, the limit holds.
+
+### Combined Example
+
+Use both together for fine-grained control:
+
+```typescript
+class CommentTransformer extends AbstractTransformer<Comment, PublicComment, { db: Database }> {
+  constructor() {
+    super({ concurrency: 10 }) // 10 items in parallel
+  }
+
+  cache = {
+    userProfile: new Cache((userId: string) => auth.getUser(userId)),
+  }
+
+  includesConcurrency = {
+    author: 5,  // Max 5 concurrent auth calls
+  }
+
+  data(input: Comment): PublicComment {
+    return { id: input.id, content: input.content }
+  }
+
+  includesMap = {
+    author: async (input: Comment) => {
+      const user = await this.cache.userProfile.call(input.userId)
+      return { name: user.name, avatarUrl: user.picture }
+    },
+  }
+}
+```
+
+### Important Notes
+
+- **Opt-in**: Without configuration, behavior is identical to before (unlimited parallelism). Existing code is unaffected.
+- **Instance-level**: Limits are shared across all calls on the same transformer instance. In server environments where one instance handles multiple requests, concurrent requests share the same semaphore.
+- **Batch methods only**: `transform()` / `_transform()` are not affected by `concurrency` — only `transformMany` / `_transformMany` are throttled. Per-include limits still apply to both single and batch transforms.
+
 ## API Reference
 
 ### AbstractTransformer

--- a/src/abstractTransformer.ts
+++ b/src/abstractTransformer.ts
@@ -36,10 +36,17 @@ abstract class AbstractTransformer<
 	 * Creates a new transformer instance.
 	 * @param params - Configuration options for the transformer.
 	 * @param params.clearCacheOnTransform - Whether to clear the cache after each transform call. Defaults to `true`.
+	 * @param params.concurrency - Maximum number of items to process in parallel in `transformMany` / `_transformMany`. Defaults to unlimited. Does not apply to single-item `transform` / `_transform`.
 	 */
 	constructor(params?: { clearCacheOnTransform?: boolean; concurrency?: number }) {
 		this.clearCacheOnTransform = params?.clearCacheOnTransform ?? true
-		if (params?.concurrency !== undefined) this.semaphore = new Semaphore(params.concurrency)
+		if (params?.concurrency !== undefined) {
+			try {
+				this.semaphore = new Semaphore(params.concurrency)
+			} catch {
+				throw new Error(`[T7M] concurrency must be a positive integer, got ${params.concurrency}`)
+			}
+		}
 	}
 
 	// MARK: Data
@@ -61,6 +68,18 @@ abstract class AbstractTransformer<
 		[K in Includes]: IncludeFunction<TInput, TOutput, K, Props>
 	}> = {}
 
+	/**
+	 * Concurrency limits for individual include functions.
+	 * When set, limits the number of concurrent invocations of a specific include function across all items.
+	 * Include keys not listed here remain unlimited.
+	 * @example
+	 * ```ts
+	 * protected readonly includesConcurrency = {
+	 *   posts: 3,   // max 3 concurrent 'posts' include calls
+	 *   avatar: 2,  // max 2 concurrent 'avatar' include calls
+	 * }
+	 * ```
+	 */
 	protected readonly includesConcurrency: Partial<{
 		[K in Includes]: number
 	}> = {}
@@ -72,7 +91,15 @@ abstract class AbstractTransformer<
 			this._includeSemaphores = {} as Partial<Record<Includes, Semaphore>>
 			for (const key of Object.keys(this.includesConcurrency) as Includes[]) {
 				const limit = this.includesConcurrency[key]
-				if (limit !== undefined) this._includeSemaphores[key] = new Semaphore(limit)
+				if (limit !== undefined) {
+					try {
+						this._includeSemaphores[key] = new Semaphore(limit)
+					} catch {
+						throw new Error(
+							`[T7M] includesConcurrency limit for '${String(key)}' must be a positive integer, got ${limit}`
+						)
+					}
+				}
 			}
 		}
 		return this._includeSemaphores

--- a/src/abstractTransformer.ts
+++ b/src/abstractTransformer.ts
@@ -1,4 +1,5 @@
 import type { AnyCache, Cache } from './cache'
+import { Semaphore } from './semaphore'
 import type { OnlyPossiblyUndefined } from './types'
 
 /**
@@ -28,6 +29,7 @@ abstract class AbstractTransformer<
 	Includes extends keyof OnlyPossiblyUndefined<TOutput> = keyof OnlyPossiblyUndefined<TOutput>,
 > {
 	protected clearCacheOnTransform: boolean
+	private readonly semaphore?: Semaphore
 
 	// MARK: Constructor
 	/**
@@ -35,8 +37,9 @@ abstract class AbstractTransformer<
 	 * @param params - Configuration options for the transformer.
 	 * @param params.clearCacheOnTransform - Whether to clear the cache after each transform call. Defaults to `true`.
 	 */
-	constructor(params?: { clearCacheOnTransform?: boolean }) {
+	constructor(params?: { clearCacheOnTransform?: boolean; concurrency?: number }) {
 		this.clearCacheOnTransform = params?.clearCacheOnTransform ?? true
+		if (params?.concurrency !== undefined) this.semaphore = new Semaphore(params.concurrency)
 	}
 
 	// MARK: Data
@@ -57,6 +60,23 @@ abstract class AbstractTransformer<
 	protected readonly includesMap: Partial<{
 		[K in Includes]: IncludeFunction<TInput, TOutput, K, Props>
 	}> = {}
+
+	protected readonly includesConcurrency: Partial<{
+		[K in Includes]: number
+	}> = {}
+
+	private _includeSemaphores?: Partial<Record<Includes, Semaphore>>
+
+	private get includeSemaphores(): Partial<Record<Includes, Semaphore>> {
+		if (!this._includeSemaphores) {
+			this._includeSemaphores = {} as Partial<Record<Includes, Semaphore>>
+			for (const key of Object.keys(this.includesConcurrency) as Includes[]) {
+				const limit = this.includesConcurrency[key]
+				if (limit !== undefined) this._includeSemaphores[key] = new Semaphore(limit)
+			}
+		}
+		return this._includeSemaphores
+	}
 
 	// MARK: Cache
 	readonly cache: Record<string, AnyCache> = {}
@@ -133,6 +153,11 @@ abstract class AbstractTransformer<
 		})
 	}
 
+	private runTransform(input: TInput, props: Props, includes: (Includes | string)[]): Promise<TOutput> {
+		const exec = () => this.__transform(input, props, includes)
+		return this.semaphore ? this.semaphore.run(exec) : exec()
+	}
+
 	/**
 	 * Transforms a single input object.
 	 * @param params The parameters for the transformation.
@@ -164,7 +189,7 @@ abstract class AbstractTransformer<
 	): Promise<TOutput[]> {
 		const { inputs, props, includes, unsafeIncludes } = params
 		const combinedIncludes = [...(includes || []), ...(unsafeIncludes || [])]
-		return Promise.all(inputs.map(input => this.__transform(input, props as Props, combinedIncludes)))
+		return Promise.all(inputs.map(input => this.runTransform(input, props as Props, combinedIncludes)))
 	}
 
 	// Generic functions
@@ -202,7 +227,7 @@ abstract class AbstractTransformer<
 		const { inputs, props, includes, unsafeIncludes } = params
 		const combinedIncludes = [...(includes || []), ...(unsafeIncludes || [])]
 		this.onBeforeTransform()
-		const outputArray = await Promise.all(inputs.map(input => this.__transform(input, props, combinedIncludes)))
+		const outputArray = await Promise.all(inputs.map(input => this.runTransform(input, props, combinedIncludes)))
 		if (this.clearCacheOnTransform) this.clearCache()
 		this.onAfterTransform()
 		return outputArray
@@ -231,11 +256,10 @@ abstract class AbstractTransformer<
 				validIncludes.map(async include => {
 					if (!this.includesMap[include]) throw new Error(`Include function not found in includesMap`)
 					try {
-						;(data[include] as TOutput[Includes]) = await this.includesMap[include](
-							input,
-							props,
-							otherIncludes
-						)
+						const includeFn = this.includesMap[include]!
+						const exec = () => includeFn(input, props, otherIncludes)
+						const semaphore = this.includeSemaphores[include]
+						;(data[include] as TOutput[Includes]) = await (semaphore ? semaphore.run(exec) : exec())
 					} catch (error) {
 						// Re-throw the error to maintain the expected behavior
 						throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { AbstractTransformer } from './abstractTransformer'
 export { Cache } from './cache'
+export { Semaphore } from './semaphore'
 export type { IncludesOf, InputOf, OutputOf, PropsOf } from './typeHelper'

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -1,11 +1,31 @@
+/**
+ * Limits concurrent async operations to a fixed number.
+ * Tasks exceeding the limit are queued and run as slots free up.
+ *
+ * Transformers have built-in concurrency control via the `concurrency` option —
+ * use this class directly only when you need standalone concurrency limiting outside of transformers.
+ *
+ * @example
+ * ```ts
+ * const semaphore = new Semaphore(5)
+ * const results = await Promise.all(
+ *     urls.map(url => semaphore.run(() => fetch(url)))
+ * )
+ * ```
+ */
 class Semaphore {
 	private queue: (() => void)[] = []
 	private active = 0
 
 	constructor(private readonly limit: number) {
-		if (limit < 1) throw new Error('Semaphore limit must be at least 1')
+		if (!Number.isInteger(limit) || limit < 1) throw new Error('Semaphore limit must be a positive integer')
 	}
 
+	/**
+	 * Executes `fn` when a concurrency slot is available, queuing if at capacity.
+	 * @param fn - The async (or sync) function to execute
+	 * @returns The resolved return value of `fn`
+	 */
 	async run<T>(fn: () => T | Promise<T>): Promise<T> {
 		while (this.active >= this.limit) {
 			await new Promise<void>(resolve => this.queue.push(resolve))

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -1,0 +1,23 @@
+class Semaphore {
+	private queue: (() => void)[] = []
+	private active = 0
+
+	constructor(private readonly limit: number) {
+		if (limit < 1) throw new Error('Semaphore limit must be at least 1')
+	}
+
+	async run<T>(fn: () => T | Promise<T>): Promise<T> {
+		while (this.active >= this.limit) {
+			await new Promise<void>(resolve => this.queue.push(resolve))
+		}
+		this.active++
+		try {
+			return await fn()
+		} finally {
+			this.active--
+			this.queue.shift()?.()
+		}
+	}
+}
+
+export { Semaphore }

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'bun:test'
+import { AbstractTransformer } from '../src/abstractTransformer'
+
+interface Item {
+	id: number
+}
+
+interface ItemOutput {
+	id: number
+	resolved?: string
+}
+
+describe('Concurrency - transformMany item throttle', () => {
+	it('should limit concurrent transformMany items', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class ThrottledTransformer extends AbstractTransformer<Item, ItemOutput> {
+			constructor() {
+				super({ concurrency: 3 })
+			}
+
+			async data(input: Item): Promise<ItemOutput> {
+				active++
+				maxActive = Math.max(maxActive, active)
+				await new Promise(r => setTimeout(r, 20))
+				active--
+				return { id: input.id }
+			}
+		}
+
+		const transformer = new ThrottledTransformer()
+		const inputs = Array.from({ length: 10 }, (_, i) => ({ id: i }))
+
+		const results = await transformer.transformMany({ inputs })
+
+		expect(results).toHaveLength(10)
+		expect(maxActive).toBeLessThanOrEqual(3)
+		expect(maxActive).toBeGreaterThan(1) // actually ran in parallel
+	})
+
+	it('should serialize with concurrency: 1', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class SerialTransformer extends AbstractTransformer<Item, ItemOutput> {
+			constructor() {
+				super({ concurrency: 1 })
+			}
+
+			async data(input: Item): Promise<ItemOutput> {
+				active++
+				maxActive = Math.max(maxActive, active)
+				await new Promise(r => setTimeout(r, 10))
+				active--
+				return { id: input.id }
+			}
+		}
+
+		const transformer = new SerialTransformer()
+		const inputs = Array.from({ length: 5 }, (_, i) => ({ id: i }))
+
+		const results = await transformer.transformMany({ inputs })
+
+		expect(results).toHaveLength(5)
+		expect(maxActive).toBe(1) // strictly serial
+	})
+
+	it('should not throttle when concurrency is not set', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class UnthrottledTransformer extends AbstractTransformer<Item, ItemOutput> {
+			async data(input: Item): Promise<ItemOutput> {
+				active++
+				maxActive = Math.max(maxActive, active)
+				await new Promise(r => setTimeout(r, 20))
+				active--
+				return { id: input.id }
+			}
+		}
+
+		const transformer = new UnthrottledTransformer()
+		const inputs = Array.from({ length: 10 }, (_, i) => ({ id: i }))
+
+		const results = await transformer.transformMany({ inputs })
+
+		expect(results).toHaveLength(10)
+		expect(maxActive).toBe(10) // all ran in parallel
+	})
+
+	it('should also throttle _transformMany', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class ThrottledTransformer extends AbstractTransformer<Item, ItemOutput> {
+			constructor() {
+				super({ concurrency: 2 })
+			}
+
+			async data(input: Item): Promise<ItemOutput> {
+				active++
+				maxActive = Math.max(maxActive, active)
+				await new Promise(r => setTimeout(r, 20))
+				active--
+				return { id: input.id }
+			}
+		}
+
+		const transformer = new ThrottledTransformer()
+		const inputs = Array.from({ length: 6 }, (_, i) => ({ id: i }))
+
+		const results = await transformer._transformMany({ inputs, props: undefined })
+
+		expect(results).toHaveLength(6)
+		expect(maxActive).toBeLessThanOrEqual(2)
+	})
+})
+
+describe('Concurrency - per-include throttle', () => {
+	it('should limit concurrent calls for a specific include', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class IncludeThrottledTransformer extends AbstractTransformer<Item, ItemOutput> {
+			data(input: Item): ItemOutput {
+				return { id: input.id }
+			}
+
+			includesMap = {
+				resolved: async (input: Item) => {
+					active++
+					maxActive = Math.max(maxActive, active)
+					await new Promise(r => setTimeout(r, 20))
+					active--
+					return `resolved-${input.id}`
+				},
+			}
+
+			includesConcurrency = {
+				resolved: 2,
+			}
+		}
+
+		const transformer = new IncludeThrottledTransformer()
+		const inputs = Array.from({ length: 10 }, (_, i) => ({ id: i }))
+
+		const results = await transformer.transformMany({
+			inputs,
+			includes: ['resolved'],
+		})
+
+		expect(results).toHaveLength(10)
+		expect(results[0]!.resolved).toBe('resolved-0')
+		expect(results[9]!.resolved).toBe('resolved-9')
+		expect(maxActive).toBeLessThanOrEqual(2)
+		expect(maxActive).toBeGreaterThan(1)
+	})
+
+	it('should not throttle includes without concurrency config', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class UnthrottledIncludeTransformer extends AbstractTransformer<Item, ItemOutput> {
+			data(input: Item): ItemOutput {
+				return { id: input.id }
+			}
+
+			includesMap = {
+				resolved: async (input: Item) => {
+					active++
+					maxActive = Math.max(maxActive, active)
+					await new Promise(r => setTimeout(r, 20))
+					active--
+					return `resolved-${input.id}`
+				},
+			}
+		}
+
+		const transformer = new UnthrottledIncludeTransformer()
+		const inputs = Array.from({ length: 10 }, (_, i) => ({ id: i }))
+
+		const results = await transformer.transformMany({
+			inputs,
+			includes: ['resolved'],
+		})
+
+		expect(results).toHaveLength(10)
+		expect(maxActive).toBe(10)
+	})
+
+	it('should allow combining item concurrency and include concurrency', async () => {
+		let itemActive = 0
+		let maxItemActive = 0
+		let includeActive = 0
+		let maxIncludeActive = 0
+
+		class CombinedThrottleTransformer extends AbstractTransformer<Item, ItemOutput> {
+			constructor() {
+				super({ concurrency: 3 })
+			}
+
+			async data(input: Item): Promise<ItemOutput> {
+				itemActive++
+				maxItemActive = Math.max(maxItemActive, itemActive)
+				await new Promise(r => setTimeout(r, 10))
+				itemActive--
+				return { id: input.id }
+			}
+
+			includesMap = {
+				resolved: async (input: Item) => {
+					includeActive++
+					maxIncludeActive = Math.max(maxIncludeActive, includeActive)
+					await new Promise(r => setTimeout(r, 20))
+					includeActive--
+					return `resolved-${input.id}`
+				},
+			}
+
+			includesConcurrency = {
+				resolved: 2,
+			}
+		}
+
+		const transformer = new CombinedThrottleTransformer()
+		const inputs = Array.from({ length: 10 }, (_, i) => ({ id: i }))
+
+		const results = await transformer.transformMany({
+			inputs,
+			includes: ['resolved'],
+		})
+
+		expect(results).toHaveLength(10)
+		expect(maxItemActive).toBeLessThanOrEqual(3)
+		expect(maxIncludeActive).toBeLessThanOrEqual(2)
+	})
+})

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -234,5 +234,107 @@ describe('Concurrency - per-include throttle', () => {
 		expect(results).toHaveLength(10)
 		expect(maxItemActive).toBeLessThanOrEqual(3)
 		expect(maxIncludeActive).toBeLessThanOrEqual(2)
+		expect(maxItemActive).toBeGreaterThan(1) // actually ran items in parallel
+		expect(maxIncludeActive).toBeGreaterThan(1) // actually ran includes in parallel
+	})
+})
+
+describe('Concurrency - error handling', () => {
+	it('should release semaphore slot when data() throws', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class ErrorTransformer extends AbstractTransformer<Item, ItemOutput> {
+			constructor() {
+				super({ concurrency: 2 })
+			}
+
+			async data(input: Item): Promise<ItemOutput> {
+				active++
+				maxActive = Math.max(maxActive, active)
+				await new Promise(r => setTimeout(r, 10))
+				active--
+				if (input.id === 3) throw new Error('data error')
+				return { id: input.id }
+			}
+		}
+
+		const transformer = new ErrorTransformer()
+		const inputs = Array.from({ length: 6 }, (_, i) => ({ id: i }))
+
+		await expect(transformer.transformMany({ inputs })).rejects.toThrow('data error')
+		expect(maxActive).toBeLessThanOrEqual(2)
+	})
+
+	it('should release include semaphore slot when include throws', async () => {
+		let active = 0
+		let maxActive = 0
+
+		class IncludeErrorTransformer extends AbstractTransformer<Item, ItemOutput> {
+			data(input: Item): ItemOutput {
+				return { id: input.id }
+			}
+
+			includesMap = {
+				resolved: async (input: Item) => {
+					active++
+					maxActive = Math.max(maxActive, active)
+					await new Promise(r => setTimeout(r, 10))
+					active--
+					if (input.id === 2) throw new Error('include error')
+					return `resolved-${input.id}`
+				},
+			}
+
+			includesConcurrency = {
+				resolved: 1,
+			}
+		}
+
+		const transformer = new IncludeErrorTransformer()
+		const inputs = Array.from({ length: 4 }, (_, i) => ({ id: i }))
+
+		await expect(transformer.transformMany({ inputs, includes: ['resolved'] })).rejects.toThrow('include error')
+		expect(maxActive).toBeLessThanOrEqual(1)
+	})
+})
+
+describe('Concurrency - validation', () => {
+	it('should throw for invalid concurrency values', () => {
+		expect(() => {
+			class Bad extends AbstractTransformer<Item, ItemOutput> {
+				constructor() {
+					super({ concurrency: 0 })
+				}
+				data(input: Item): ItemOutput {
+					return { id: input.id }
+				}
+			}
+			new Bad()
+		}).toThrow()
+
+		expect(() => {
+			class Bad extends AbstractTransformer<Item, ItemOutput> {
+				constructor() {
+					super({ concurrency: -1 })
+				}
+				data(input: Item): ItemOutput {
+					return { id: input.id }
+				}
+			}
+			new Bad()
+		}).toThrow()
+
+		expect(() => {
+			class Bad extends AbstractTransformer<Item, ItemOutput> {
+				constructor() {
+					super({ concurrency: 1.5 })
+				}
+				data(input: Item): ItemOutput {
+					return { id: input.id }
+				}
+			}
+			new Bad()
+		}).toThrow()
 	})
 })

--- a/tests/semaphore.test.ts
+++ b/tests/semaphore.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+import { Semaphore } from '../src/semaphore'
+
+describe('Semaphore', () => {
+	it('should limit concurrency to the specified value', async () => {
+		const semaphore = new Semaphore(2)
+		let active = 0
+		let maxActive = 0
+
+		const task = () =>
+			semaphore.run(async () => {
+				active++
+				maxActive = Math.max(maxActive, active)
+				await new Promise(r => setTimeout(r, 50))
+				active--
+			})
+
+		await Promise.all([task(), task(), task(), task(), task()])
+
+		expect(maxActive).toBe(2)
+	})
+
+	it('should resolve all tasks', async () => {
+		const semaphore = new Semaphore(2)
+		const results: number[] = []
+
+		const task = (n: number) =>
+			semaphore.run(async () => {
+				await new Promise(r => setTimeout(r, 10))
+				results.push(n)
+				return n
+			})
+
+		const returned = await Promise.all([task(1), task(2), task(3), task(4)])
+
+		expect(returned).toEqual([1, 2, 3, 4])
+		expect(results).toHaveLength(4)
+	})
+
+	it('should propagate errors without breaking the queue', async () => {
+		const semaphore = new Semaphore(1)
+
+		const failingTask = semaphore.run(async () => {
+			throw new Error('fail')
+		})
+
+		await expect(failingTask).rejects.toThrow('fail')
+
+		// Semaphore should still work after error
+		const result = await semaphore.run(async () => 'ok')
+		expect(result).toBe('ok')
+	})
+
+	it('should throw for limit less than 1', () => {
+		expect(() => new Semaphore(0)).toThrow('Semaphore limit must be at least 1')
+		expect(() => new Semaphore(-1)).toThrow('Semaphore limit must be at least 1')
+	})
+
+	it('should handle synchronous return values', async () => {
+		const semaphore = new Semaphore(3)
+		const result = await semaphore.run(async () => 42)
+		expect(result).toBe(42)
+	})
+})

--- a/tests/semaphore.test.ts
+++ b/tests/semaphore.test.ts
@@ -52,8 +52,14 @@ describe('Semaphore', () => {
 	})
 
 	it('should throw for limit less than 1', () => {
-		expect(() => new Semaphore(0)).toThrow('Semaphore limit must be at least 1')
-		expect(() => new Semaphore(-1)).toThrow('Semaphore limit must be at least 1')
+		expect(() => new Semaphore(0)).toThrow('Semaphore limit must be a positive integer')
+		expect(() => new Semaphore(-1)).toThrow('Semaphore limit must be a positive integer')
+	})
+
+	it('should throw for non-integer limit', () => {
+		expect(() => new Semaphore(1.5)).toThrow('Semaphore limit must be a positive integer')
+		expect(() => new Semaphore(NaN)).toThrow('Semaphore limit must be a positive integer')
+		expect(() => new Semaphore(Infinity)).toThrow('Semaphore limit must be a positive integer')
 	})
 
 	it('should handle synchronous return values', async () => {


### PR DESCRIPTION
## Summary

- Adds a `Semaphore` utility for async concurrency control
- Adds `concurrency` constructor param to `AbstractTransformer` — limits parallel items in `transformMany`/`_transformMany`
- Adds `includesConcurrency` property — limits concurrent invocations of individual include functions across all items
- Fully opt-in: no config = identical behavior to before (non-breaking)

## Usage

```ts
class UserTransformer extends AbstractTransformer<User, UserOutput> {
  constructor() {
    super({ concurrency: 5 }) // max 5 items at a time
  }

  includesConcurrency = {
    posts: 3, // max 3 concurrent 'posts' include calls
  }
}
```

## Test plan

- [x] Semaphore unit tests (5 tests): concurrency limiting, error propagation, validation
- [x] Item-level throttle tests (4 tests): throttled, unthrottled, serialization, `_transformMany`
- [x] Per-include throttle tests (3 tests): throttled, unthrottled, combined with item throttle
- [x] All 154 existing tests pass (no regressions)
- [x] Lint, typecheck, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)