### PR TITLE
fix: security hardening, bug fixes, and cleanup

### DIFF
--- a/.claude/skills/build-transformer/reference.md
+++ b/.claude/skills/build-transformer/reference.md
@@ -114,16 +114,16 @@ For object arguments, specify which keys to use for the cache key:
 ```typescript
 const cached = new Cache(
 	(params: { id: number; timestamp: number }) => db.users.findOne({ id: params.id }),
-	'id' // Only cache on 'id', ignore 'timestamp'
+	{ on: ['id'] } // Only cache on 'id', ignore 'timestamp'
 )
-// Multiple keys: new Cache(fn, 'id', 'type')
+// Multiple keys: new Cache(fn, { on: ['id', 'type'] })
+// Limit cache size: new Cache(fn, { maxSize: 100 })
 ```
 
 ### Cache Lifecycle
 
 - Cache lives on the transformer instance — reuse one instance per request
-- No TTL. The Hono middleware clears caches after each response
-- When calling `transform()`/`transformMany()` directly, call `clearCache()` yourself
+- No TTL. All transform methods (`transform`, `transformMany`, `_transform`, `_transformMany`) auto-clear caches after completion when `clearCacheOnTransform` is true (default)
 - `clearCacheOnTransform` is set on `AbstractTransformer` via `super()`, **not** on `Cache`
 - `transformMany()` processes all items in parallel via `Promise.all`, so duplicate cache calls across items are deduplicated
 
@@ -131,9 +131,6 @@ const cached = new Cache(
 constructor() {
 	super({ clearCacheOnTransform: false }) // Disable auto-clear
 }
-
-// When not using the Hono middleware, clear cache manually
-transformer.clearCache()
 ```
 
 ## Nested Transformers
@@ -168,7 +165,8 @@ Circular references between transformers are handled safely — cache clearing u
 ## `transform()` vs `_transform()`
 
 - `transform()` / `transformMany()`: **Public API.** Props conditionally required. Use these in your application code.
-- `_transform()` / `_transformMany()`: Used by Hono middleware internally. Props always required. Handles cache lifecycle (before/after hooks). Don't call these directly — the middleware does it for you.
+- `_transform()` / `_transformMany()`: Used by Hono middleware and Elysia plugin internally. Props always required. Don't call these directly — the middleware/plugin does it for you.
+- Both APIs manage cache lifecycle (activeTransforms counter + clearCacheOnTransform).
 
 ## Type Utilities
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,16 @@ on:
       - 'v*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        run: git merge-base --is-ancestor ${{ github.sha }} origin/main
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -26,8 +31,14 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - run: bun run lint
+
+      - run: bun run typecheck
+
       - run: bun run build
 
       - run: bun test
 
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,14 +15,14 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
 
       - run: bun install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,5 +40,3 @@ jobs:
       - run: bun test
 
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Claude Superpowers
 docs/plans/**
+
+# Private keys / certificates
+*.pem
+*.key
+*.cert
+
+# Local databases
+*.sqlite
+*.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ dist/                          # Build output (git-ignored)
 ### 1. `transform()` vs `_transform()`
 
 - `transform()` / `transformMany()`: Public API. Props conditionally required.
-- `_transform()` / `_transformMany()`: Used by Hono middleware and Elysia plugin. Props always required. Handles cache lifecycle.
+- `_transform()` / `_transformMany()`: Used by Hono middleware and Elysia plugin. Props always required.
+- Both APIs manage cache lifecycle (activeTransforms counter + clearCacheOnTransform).
 - Don't confuse them — both Hono middleware and Elysia plugin call `_transform()`, not `transform()`.
 
 ### 2. All transform methods take a params OBJECT
@@ -100,7 +101,7 @@ constructor() {
   super({ clearCacheOnTransform: false })
 }
 
-// ❌ WRONG
+// ❌ WRONG — Cache options are { on?, maxSize? }, not clearCacheOnTransform
 new Cache(fn, { clearCacheOnTransform: false })
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,12 @@ TypeScript library for API output transformation. Triple export: `t7m` (core) + 
 
 - **Indent**: Tabs (width 4)
 - **Quotes**: Single
-- **Semicolons**: None
+- **Semicolons**: asNeeded
 - **Line width**: 120 chars
 - **Line endings**: LF
 - **Arrow parens**: asNeeded (`x => x`, not `(x) => x`)
 - **Trailing commas**: ES5
-- **noExplicitAny**: warn — use `// biome-ignore lint/suspicious/noExplicitAny: reason` when needed
+- **noExplicitAny**: warn in src, off in tests
 
 ## Architecture
 
@@ -84,7 +84,7 @@ this.cache.userProfile.get(input.userId)
 ### 4. `transformers` is a Record, not an array
 
 ```typescript
-// ✅ CORRECT — Record<string, Transformer | Cache<() => Transformer>>
+// ✅ CORRECT — Record<string, AnyAbstractTransformer | Cache<() => AnyAbstractTransformer>>
 transformers = { author: this.authorTransformer }
 transformers = { author: new Cache(() => new AuthorTransformer()) }
 
@@ -108,7 +108,7 @@ new Cache(fn, { clearCacheOnTransform: false })
 
 - `data(input, props)` → `protected abstract` — never call from outside
 - `includesMap` → `protected readonly` — initialize in class body
-- `cache` → `public readonly`
+- `cache` → `readonly` (implicitly public)
 - `transformers` → `public` (not readonly)
 
 ### 7. Includes only work with optional output properties
@@ -175,6 +175,9 @@ constructor() {
 
 ## Git
 
+- **Separate commits** per logical change (e.g. data layer, UI components, refactors)
+- **Short messages**, no description body, imperative mood, max ~60 chars
 - **Commit format**: `type: description` (lowercase) — e.g., `fix: loosen perf test threshold`
+- **Allowed prefixes**: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `perf`, `ci`
 - **Main branch**: `main`
 - **CI**: GitHub Actions, publishes on `v*` tags

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Works with Hono and Elysia. No overhead — 1,000 objects with includes in under
 
 *t7m = t(ransfor)m - 7 letters between t and m*
 
+## AI Agent Skill
+
+t7m ships with a [Claude Code skill](https://code.claude.com/docs/en/skills) that teaches AI coding agents how to build transformers correctly — includes, cache, props, nested transformers, and framework integration.
+
+Install it with the [Vercel Skills CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add tkoehlerlg/t7m
+```
+
+This works with Claude Code, Cursor, Codex, and other agents that support the open agent skills standard.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -227,18 +227,20 @@ For object arguments, specify which keys to use for the cache key:
 ```typescript
 const cached = new Cache(
   (params: { id: number; timestamp: number }) => db.users.findOne({ id: params.id }),
-  "id" // Only cache on 'id', ignore 'timestamp'
+  { on: ["id"] } // Only cache on 'id', ignore 'timestamp'
 );
 
 await cached.call({ id: 1, timestamp: 100 });
 await cached.call({ id: 1, timestamp: 200 }); // Cache hit!
 ```
 
-You can specify multiple keys: `new Cache(fn, "id", "type")`
+You can specify multiple keys: `new Cache(fn, { on: ["id", "type"] })`
+
+Limit cache size with `maxSize`: `new Cache(fn, { maxSize: 100 })`
 
 ### Cache Auto-Clear
 
-By default, caches clear after each transformation when using the framework middleware. When using `transform()`/`transformMany()` directly, call `clearCache()` manually. Disable auto-clear with:
+By default, caches clear after each transformation. Disable auto-clear with:
 
 ```typescript
 class MyTransformer extends AbstractTransformer<Input, Output> {
@@ -549,7 +551,7 @@ class CommentTransformer extends AbstractTransformer<Comment, PublicComment, { d
 
 | Method | Description |
 |--------|-------------|
-| `new Cache(fn, ...keys)` | Create a cache. `fn` must take 0 or 1 argument. `keys` specifies which object properties to use as cache key (optional, accepts multiple keys). |
+| `new Cache(fn, options?)` | Create a cache. `fn` must take 0 or 1 argument. `options.on` specifies which object properties to use as cache key. `options.maxSize` limits entries (oldest evicted). |
 | `call(...args)` | Call the cached function. Same-input calls return cached result. Concurrent calls share the same promise. |
 | `clear()` | Clear all cached results. |
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ t7m exports utility types for extracting type information from transformer insta
 
 | Type | Description |
 |------|-------------|
+| `AnyAbstractTransformer` | Base type for typing transformer collections and generic utilities |
 | `InputOf<T>` | Extract the input type from a transformer |
 | `OutputOf<T>` | Extract the output type from a transformer |
 | `PropsOf<T>` | Extract the props type from a transformer |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's private vulnerability reporting:
+
+https://github.com/tkoehlerlg/t7m/security/advisories/new
+
+Do not open a public issue for security vulnerabilities.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
 	"vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
-	"files": { "ignoreUnknown": false },
+	"files": { "ignoreUnknown": false, "includes": ["**", "!dist"] },
 	"formatter": {
 		"enabled": true,
 		"formatWithErrors": false,
@@ -44,12 +44,11 @@
 	},
 	"overrides": [
 		{
-			"includes": ["dist/**/*"],
-			"formatter": {
-				"enabled": false
-			},
+			"includes": ["tests/**/*"],
 			"linter": {
-				"enabled": false
+				"rules": {
+					"suspicious": { "noExplicitAny": "off" }
+				}
 			}
 		}
 	]

--- a/biome.json
+++ b/biome.json
@@ -18,9 +18,16 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": false,
-			"correctness": { "noUnusedVariables": "error" },
-			"style": { "noInferrableTypes": "off" },
+			"recommended": true,
+			"correctness": {
+				"noUnusedVariables": "error",
+				"noUnusedFunctionParameters": "off"
+			},
+			"style": {
+				"noInferrableTypes": "off",
+				"noNonNullAssertion": "off",
+				"useShorthandFunctionType": "off"
+			},
 			"suspicious": { "noExplicitAny": "warn" }
 		}
 	},

--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,13 @@
       "name": "t7m",
       "devDependencies": {
         "@biomejs/biome": "2.1.2",
-        "@types/bun": "latest",
+        "@types/bun": "^1.2.17",
         "elysia": "^1.2",
         "hono": "^4",
       },
       "peerDependencies": {
         "elysia": "^1.2",
-        "hono": "",
+        "hono": "^4",
         "typescript": "^5",
       },
       "optionalPeers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "t7m",
-	"module": "src/index.ts",
+	"module": "dist/index.js",
 	"type": "module",
 	"author": {
 		"name": "Torben Koehler"
@@ -19,19 +19,17 @@
 	"exports": {
 		".": {
 			"import": "./dist/index.js",
-			"require": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		},
 		"./hono": {
 			"import": "./dist/hono/index.js",
-			"require": "./dist/hono/index.js",
 			"types": "./dist/hono/index.d.ts"
 		},
 		"./elysia": {
 			"import": "./dist/elysia/index.js",
-			"require": "./dist/elysia/index.js",
 			"types": "./dist/elysia/index.d.ts"
-		}
+		},
+		"./*": null
 	},
 	"typesVersions": {
 		"*": {
@@ -42,7 +40,7 @@
 	"types": "dist/index.d.ts",
 	"files": ["dist"],
 	"scripts": {
-		"build": "tsc --declaration --emitDeclarationOnly --outDir dist && NODE_ENV=production bun build src/index.ts src/hono/index.ts src/elysia/index.ts --outdir dist --target node --external hono --external elysia",
+		"build": "rm -rf dist && tsc --declaration --emitDeclarationOnly --outDir dist && NODE_ENV=production bun build src/index.ts src/hono/index.ts src/elysia/index.ts --outdir dist --target node --external hono --external elysia",
 		"dev": "bun --watch src/index.ts",
 		"format": "biome format --write",
 		"lint": "biome lint && biome check",
@@ -55,7 +53,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.1.2",
-		"@types/bun": "latest",
+		"@types/bun": "^1.2.17",
 		"elysia": "^1.2",
 		"hono": "^4"
 	},

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	"peerDependencies": {
 		"typescript": "^5",
 		"elysia": "^1.2",
-		"hono": ""
+		"hono": "^4"
 	},
 	"peerDependenciesMeta": {
 		"elysia": {

--- a/src/abstractTransformer.ts
+++ b/src/abstractTransformer.ts
@@ -124,7 +124,7 @@ abstract class AbstractTransformer<
 	// MARK: Transformer
 	transformers: Record<string, AnyAbstractTransformer | Cache<() => AnyAbstractTransformer>> = {}
 
-	// Tracks how many _transform/_transformMany calls are currently active on this node (or any ancestor).
+	// Tracks how many transform/_transform/transformMany/_transformMany calls are currently active.
 	// Cache is only cleared when this reaches 0, preventing premature clearing during concurrent transforms.
 	private activeTransforms = 0
 
@@ -159,7 +159,13 @@ abstract class AbstractTransformer<
 	): Promise<TOutput> {
 		const { input, props, includes, unsafeIncludes } = params
 		const combinedIncludes = [...(includes || []), ...(unsafeIncludes || [])]
-		return this.__transform(input, props as Props, combinedIncludes)
+		this.adjustActiveTransforms(1)
+		try {
+			return await this.__transform(input, props as Props, combinedIncludes)
+		} finally {
+			this.adjustActiveTransforms(-1)
+			if (this.activeTransforms === 0 && this.clearCacheOnTransform) this.clearCache()
+		}
 	}
 
 	/**
@@ -176,7 +182,13 @@ abstract class AbstractTransformer<
 	): Promise<TOutput[]> {
 		const { inputs, props, includes, unsafeIncludes } = params
 		const combinedIncludes = [...(includes || []), ...(unsafeIncludes || [])]
-		return Promise.all(inputs.map(input => this.runTransform(input, props as Props, combinedIncludes)))
+		this.adjustActiveTransforms(1)
+		try {
+			return await Promise.all(inputs.map(input => this.runTransform(input, props as Props, combinedIncludes)))
+		} finally {
+			this.adjustActiveTransforms(-1)
+			if (this.activeTransforms === 0 && this.clearCacheOnTransform) this.clearCache()
+		}
 	}
 
 	// Generic functions

--- a/src/abstractTransformer.ts
+++ b/src/abstractTransformer.ts
@@ -239,9 +239,9 @@ abstract class AbstractTransformer<
 		includes = Array.from(new Set(includes))
 		// Handle includes
 		if (includes.length > 0 && typeof data === 'object' && data !== null) {
-			const otherIncludes = includes.filter(include => !(include in this.includesMap))
+			const otherIncludes = includes.filter(include => !Object.hasOwn(this.includesMap, include))
 			const validIncludes = includes
-				.filter(include => include in this.includesMap)
+				.filter(include => Object.hasOwn(this.includesMap, include))
 				.map(include => include as Includes)
 			await Promise.all(
 				validIncludes.map(async include => {

--- a/src/abstractTransformer.ts
+++ b/src/abstractTransformer.ts
@@ -28,7 +28,7 @@ abstract class AbstractTransformer<
 	Props extends Record<string, unknown> | undefined = undefined,
 	Includes extends keyof OnlyPossiblyUndefined<TOutput> = keyof OnlyPossiblyUndefined<TOutput>,
 > {
-	protected clearCacheOnTransform: boolean
+	protected readonly clearCacheOnTransform: boolean
 	private readonly semaphore?: Semaphore
 
 	// MARK: Constructor
@@ -121,62 +121,22 @@ abstract class AbstractTransformer<
 		})
 	}
 
-	// Executed in child transformers to prevent them from clearing cache mid-transform
-	private originalClearCacheOnTransform: boolean | null = null
-
-	private disableClearCacheForTransformers = (visited: Set<AnyAbstractTransformer>) => {
-		if (visited.has(this)) return // Already visited, prevent infinite loop
-		visited.add(this)
-		// Only backup if not already backed up (prevents overwriting with already-disabled value)
-		if (this.originalClearCacheOnTransform === null) this.originalClearCacheOnTransform = this.clearCacheOnTransform
-		this.clearCacheOnTransform = false
-		Object.keys(this.transformers).forEach(key => {
-			const transformer = this.transformers[key]!
-			if ('call' in transformer) {
-				transformer.call().disableClearCacheForTransformers(visited)
-			} else transformer.disableClearCacheForTransformers(visited)
-		})
-	}
-
-	private restoreClearCacheForTransformers = (visited: Set<AnyAbstractTransformer>) => {
-		if (visited.has(this)) return
-		visited.add(this)
-		if (this.originalClearCacheOnTransform !== null) {
-			this.clearCacheOnTransform = this.originalClearCacheOnTransform
-			this.originalClearCacheOnTransform = null
-		}
-		Object.keys(this.transformers).forEach(key => {
-			const transformer = this.transformers[key]!
-			if ('call' in transformer) {
-				transformer.call().restoreClearCacheForTransformers(visited)
-			} else transformer.restoreClearCacheForTransformers(visited)
-		})
-	}
-
 	// MARK: Transformer
 	transformers: Record<string, AnyAbstractTransformer | Cache<() => AnyAbstractTransformer>> = {}
 
-	private onBeforeTransform = () => {
-		// Already executed by parent transformer, skip
-		if (this.originalClearCacheOnTransform !== null) return
-		const visited = new Set<AnyAbstractTransformer>([this])
-		Object.keys(this.transformers).forEach(key => {
-			const transformer = this.transformers[key]!
-			if ('call' in transformer) {
-				transformer.call().disableClearCacheForTransformers(visited)
-			} else transformer.disableClearCacheForTransformers(visited)
-		})
-	}
+	// Tracks how many _transform/_transformMany calls are currently active on this node (or any ancestor).
+	// Cache is only cleared when this reaches 0, preventing premature clearing during concurrent transforms.
+	private activeTransforms = 0
 
-	private onAfterTransform = () => {
-		// Was executed by parent, parent will restore
-		if (this.originalClearCacheOnTransform !== null) return
-		const visited = new Set<AnyAbstractTransformer>([this])
+	private adjustActiveTransforms = (delta: 1 | -1, visited: Set<AnyAbstractTransformer> = new Set()) => {
+		if (visited.has(this)) return
+		visited.add(this)
+		this.activeTransforms += delta
 		Object.keys(this.transformers).forEach(key => {
 			const transformer = this.transformers[key]!
 			if ('call' in transformer) {
-				transformer.call().restoreClearCacheForTransformers(visited)
-			} else transformer.restoreClearCacheForTransformers(visited)
+				transformer.call().adjustActiveTransforms(delta, visited)
+			} else transformer.adjustActiveTransforms(delta, visited)
 		})
 	}
 
@@ -233,11 +193,13 @@ abstract class AbstractTransformer<
 	}): Promise<TOutput> {
 		const { input, props, includes, unsafeIncludes } = params
 		const combinedIncludes = [...(includes || []), ...(unsafeIncludes || [])]
-		this.onBeforeTransform()
-		const output = await this.__transform(input, props, combinedIncludes)
-		if (this.clearCacheOnTransform) this.clearCache()
-		this.onAfterTransform()
-		return output
+		this.adjustActiveTransforms(1)
+		try {
+			return await this.__transform(input, props, combinedIncludes)
+		} finally {
+			this.adjustActiveTransforms(-1)
+			if (this.activeTransforms === 0 && this.clearCacheOnTransform) this.clearCache()
+		}
 	}
 
 	/**
@@ -253,11 +215,13 @@ abstract class AbstractTransformer<
 	}): Promise<TOutput[]> {
 		const { inputs, props, includes, unsafeIncludes } = params
 		const combinedIncludes = [...(includes || []), ...(unsafeIncludes || [])]
-		this.onBeforeTransform()
-		const outputArray = await Promise.all(inputs.map(input => this.runTransform(input, props, combinedIncludes)))
-		if (this.clearCacheOnTransform) this.clearCache()
-		this.onAfterTransform()
-		return outputArray
+		this.adjustActiveTransforms(1)
+		try {
+			return await Promise.all(inputs.map(input => this.runTransform(input, props, combinedIncludes)))
+		} finally {
+			this.adjustActiveTransforms(-1)
+			if (this.activeTransforms === 0 && this.clearCacheOnTransform) this.clearCache()
+		}
 	}
 
 	// Internal transformation function

--- a/src/elysia/plugin.ts
+++ b/src/elysia/plugin.ts
@@ -22,7 +22,7 @@ export const t7mPlugin = () =>
 			const [input, transformer, extras] = args
 			const { includes, wrapper, debug, props } = extras ?? {}
 			if (debug) log('Transforming (One):\n', input, transformer.constructor.name)
-			const processedIncludes = includes || include?.split(',')
+			const processedIncludes = includes || include?.split(',').map(s => s.trim())
 			if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 			const transformed: OutputOf<T> = await transformer._transform({
 				input,
@@ -49,7 +49,7 @@ export const t7mPlugin = () =>
 			const [inputs, transformer, extras] = args
 			const { includes, wrapper, debug, props } = extras ?? {}
 			if (debug) log('Transforming (Many):\n', inputs, transformer.constructor.name)
-			const processedIncludes = includes || include?.split(',')
+			const processedIncludes = includes || include?.split(',').map(s => s.trim())
 			if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 			const transformed: OutputOf<T>[] = await transformer._transformMany({
 				inputs,

--- a/src/elysia/plugin.ts
+++ b/src/elysia/plugin.ts
@@ -6,7 +6,8 @@ import type { TransformFn, TransformManyFn } from './types'
 
 export const t7mPlugin = () =>
 	new Elysia({ name: 't7m' }).derive({ as: 'global' }, ({ query }) => {
-		const include = (query as Record<string, string | undefined>)?.include
+		const rawInclude = (query as Record<string, unknown>)?.include
+		const include = typeof rawInclude === 'string' ? rawInclude : undefined
 
 		const transform: TransformFn = async <T extends AnyAbstractTransformer, O = OutputOf<T>>(
 			...args: [
@@ -22,7 +23,12 @@ export const t7mPlugin = () =>
 			const [input, transformer, extras] = args
 			const { includes, wrapper, debug, props } = extras ?? {}
 			if (debug) log('Transforming (One):\n', input, transformer.constructor.name)
-			const processedIncludes = includes || include?.split(',').map(s => s.trim())
+			const processedIncludes =
+				includes ||
+				include
+					?.split(',')
+					.map(s => s.trim())
+					.filter(Boolean)
 			if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 			const transformed: OutputOf<T> = await transformer._transform({
 				input,
@@ -49,7 +55,12 @@ export const t7mPlugin = () =>
 			const [inputs, transformer, extras] = args
 			const { includes, wrapper, debug, props } = extras ?? {}
 			if (debug) log('Transforming (Many):\n', inputs, transformer.constructor.name)
-			const processedIncludes = includes || include?.split(',').map(s => s.trim())
+			const processedIncludes =
+				includes ||
+				include
+					?.split(',')
+					.map(s => s.trim())
+					.filter(Boolean)
 			if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 			const transformed: OutputOf<T>[] = await transformer._transformMany({
 				inputs,

--- a/src/hono/middleware.ts
+++ b/src/hono/middleware.ts
@@ -25,7 +25,7 @@ export const t7mMiddleware = createMiddleware(async (c, next) => {
 	): Promise<JSONRespondReturn<O, U>> {
 		const { includes, wrapper, debug, props } = extras
 		if (debug) log('Transforming (One):\n', input, transformer.constructor.name)
-		const processedIncludes = includes || include?.split(',')
+		const processedIncludes = includes || include?.split(',').map(s => s.trim())
 		if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 		const transformed: OutputOf<T> = await transformer._transform({
 			input,
@@ -55,7 +55,7 @@ export const t7mMiddleware = createMiddleware(async (c, next) => {
 	): Promise<JSONRespondReturn<O, U>> {
 		const { includes, wrapper, debug, props } = extras
 		if (debug) log('Transforming (Many):\n', inputs, transformer.constructor.name)
-		const processedIncludes = includes || include?.split(',')
+		const processedIncludes = includes || include?.split(',').map(s => s.trim())
 		if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 		const transformed: OutputOf<T>[] = await transformer._transformMany({
 			inputs,

--- a/src/hono/middleware.ts
+++ b/src/hono/middleware.ts
@@ -8,7 +8,7 @@ import type { HeaderRecord, JSONRespondReturn } from './types'
 export const t7mMiddleware = createMiddleware(async (c, next) => {
 	const { include } = c.req.query()
 
-	c.transform = async function <
+	c.transform = async <
 		T extends AnyAbstractTransformer,
 		O extends { data: OutputOf<T> } | OutputOf<T> = OutputOf<T>,
 		U extends ContentfulStatusCode = ContentfulStatusCode,
@@ -22,10 +22,15 @@ export const t7mMiddleware = createMiddleware(async (c, next) => {
 		} & (PropsOf<T> extends undefined ? { props?: never } : { props: PropsOf<T> }),
 		status?: U,
 		headers?: HeaderRecord
-	): Promise<JSONRespondReturn<O, U>> {
+	): Promise<JSONRespondReturn<O, U>> => {
 		const { includes, wrapper, debug, props } = extras
 		if (debug) log('Transforming (One):\n', input, transformer.constructor.name)
-		const processedIncludes = includes || include?.split(',').map(s => s.trim())
+		const processedIncludes =
+			includes ||
+			include
+				?.split(',')
+				.map(s => s.trim())
+				.filter(Boolean)
 		if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 		const transformed: OutputOf<T> = await transformer._transform({
 			input,
@@ -38,7 +43,7 @@ export const t7mMiddleware = createMiddleware(async (c, next) => {
 		return c.json(response, status, headers)
 	}
 
-	c.transformMany = async function <
+	c.transformMany = async <
 		T extends AnyAbstractTransformer,
 		O extends { data: OutputOf<T>[] } | OutputOf<T>[] = OutputOf<T>[],
 		U extends ContentfulStatusCode = ContentfulStatusCode,
@@ -52,10 +57,15 @@ export const t7mMiddleware = createMiddleware(async (c, next) => {
 		} & (PropsOf<T> extends undefined ? { props?: never } : { props: PropsOf<T> }),
 		status?: U,
 		headers?: HeaderRecord
-	): Promise<JSONRespondReturn<O, U>> {
+	): Promise<JSONRespondReturn<O, U>> => {
 		const { includes, wrapper, debug, props } = extras
 		if (debug) log('Transforming (Many):\n', inputs, transformer.constructor.name)
-		const processedIncludes = includes || include?.split(',').map(s => s.trim())
+		const processedIncludes =
+			includes ||
+			include
+				?.split(',')
+				.map(s => s.trim())
+				.filter(Boolean)
 		if (debug && processedIncludes) log('Includes Received:', processedIncludes, transformer.constructor.name)
 		const transformed: OutputOf<T>[] = await transformer._transformMany({
 			inputs,

--- a/src/hono/types.ts
+++ b/src/hono/types.ts
@@ -1,4 +1,4 @@
-import { TypedResponse } from 'hono'
+import type { TypedResponse } from 'hono'
 import type { ResponseHeader } from 'hono/utils/headers'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { BaseMime } from 'hono/utils/mime'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AbstractTransformer } from './abstractTransformer'
+export { AbstractTransformer, type AnyAbstractTransformer, type IncludeFunction } from './abstractTransformer'
 export { Cache } from './lib/cache'
 export { Semaphore } from './lib/semaphore'
 export type { IncludesOf, InputOf, OutputOf, PropsOf } from './types'

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -25,6 +25,12 @@ class Cache<FN extends (() => any) | ((arg: any) => any)> {
 	private readonly cacheOnObjectParams?: (keyof Parameters<FN>[0])[]
 
 	/**
+	 * Optional maximum cache size. When set, the oldest entry (by insertion order) is evicted
+	 * once the cache exceeds this limit. Unset means unlimited growth (default).
+	 */
+	maxSize?: number
+
+	/**
 	 * Creates a new Cache instance.
 	 * @param fn - The function to cache
 	 * @param on - For object args: keys to use for cache key (default: all keys)
@@ -42,8 +48,8 @@ class Cache<FN extends (() => any) | ((arg: any) => any)> {
 		return keys
 			.slice()
 			.sort()
-			.map(key => `${key.toString()}:${arg[key]}`)
-			.join('-')
+			.map(key => `${key.toString()}:${JSON.stringify(arg[key])}`)
+			.join('|')
 	}
 
 	/**
@@ -55,7 +61,7 @@ class Cache<FN extends (() => any) | ((arg: any) => any)> {
 		const arg = args[0] ?? 'default-key'
 		let cacheKey: string
 		if (typeof arg !== 'object') {
-			cacheKey = arg.toString()
+			cacheKey = `${typeof arg}:${String(arg)}`
 		} else if (this.cacheOnObjectParams) {
 			cacheKey = this.objectCacheKey(this.cacheOnObjectParams, arg)
 		} else {
@@ -64,6 +70,20 @@ class Cache<FN extends (() => any) | ((arg: any) => any)> {
 		if (!this.cache.has(cacheKey)) {
 			const result = (this.fn as (...args: Parameters<FN>) => ReturnType<FN>)(...args)
 			this.cache.set(cacheKey, result as ReturnType<FN>)
+
+			// Evict oldest entry when maxSize is exceeded
+			if (this.maxSize && this.cache.size > this.maxSize) {
+				const firstKey = this.cache.keys().next().value
+				if (firstKey !== undefined) this.cache.delete(firstKey)
+			}
+
+			// Auto-evict rejected promises so transient failures don't become permanent
+			// biome-ignore lint/suspicious/noExplicitAny: need to check if result is thenable
+			if (result && typeof (result as any).catch === 'function') {
+				;(result as Promise<unknown>).catch(() => {
+					this.cache.delete(cacheKey)
+				})
+			}
 		}
 		return this.cache.get(cacheKey) as ReturnType<FN>
 	}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -15,31 +15,38 @@
  * await cached.call(1); // Returns cached result
  * ```
  *
- * @example With selective cache keys
+ * @example With selective cache keys and maxSize
  * ```ts
- * const cached = new Cache(fetchUser, 'id'); // Only cache on 'id' key
+ * const cached = new Cache(fetchUser, { on: ['id'], maxSize: 100 });
  * ```
  */
 // biome-ignore lint/suspicious/noExplicitAny: any is required for the generic type
 class Cache<FN extends (() => any) | ((arg: any) => any)> {
 	private readonly cacheOnObjectParams?: (keyof Parameters<FN>[0])[]
-
-	/**
-	 * Optional maximum cache size. When set, the oldest entry (by insertion order) is evicted
-	 * once the cache exceeds this limit. Unset means unlimited growth (default).
-	 */
-	maxSize?: number
+	private readonly maxSize?: number
 
 	/**
 	 * Creates a new Cache instance.
 	 * @param fn - The function to cache
-	 * @param on - For object args: keys to use for cache key (default: all keys)
+	 * @param options - Optional configuration
+	 * @param options.on - For object args: keys to use for cache key (default: all keys)
+	 * @param options.maxSize - Maximum cache entries. Oldest evicted when exceeded. Must be a positive integer.
 	 */
 	constructor(
 		readonly fn: FN,
-		...on: Parameters<FN>[0] extends Record<string, unknown> ? (keyof Parameters<FN>[0])[] : []
+		options?: {
+			on?: Parameters<FN>[0] extends Record<string, unknown> ? (keyof Parameters<FN>[0])[] : never
+			maxSize?: number
+		}
 	) {
-		this.cacheOnObjectParams = on.length > 0 ? on : undefined
+		const on = options?.on
+		this.cacheOnObjectParams = on && on.length > 0 ? on : undefined
+		if (options?.maxSize !== undefined) {
+			if (!Number.isInteger(options.maxSize) || options.maxSize < 1) {
+				throw new Error(`[T7M] Cache maxSize must be a positive integer, got ${options.maxSize}`)
+			}
+			this.maxSize = options.maxSize
+		}
 	}
 
 	private cache = new Map<string, ReturnType<FN>>()

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -11,7 +11,7 @@ export const log = (message: string, data?: unknown, transformerName?: string) =
 			try {
 				jsonData = JSON.stringify(data, null, 2).substring(0, 300)
 			} catch {
-				jsonData = String(data)
+				jsonData = String(data).substring(0, 300)
 			}
 		}
 		console.log(T7M_PREFIX, nameTag, message, jsonData)

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,6 +1,7 @@
 const T7M_PREFIX = '\x1b[36m[T7M]\x1b[0m'
 
 export const log = (message: string, data?: unknown, transformerName?: string) => {
+	if (typeof process !== 'undefined' && process.env?.T7M_DEBUG !== 'true') return
 	const nameTag = transformerName ? `\x1b[33m[${transformerName}]\x1b[0m` : ''
 	if (data !== undefined) {
 		const jsonData = typeof data === 'string' ? data : JSON.stringify(data, null, 2).substring(0, 300)

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -4,7 +4,16 @@ export const log = (message: string, data?: unknown, transformerName?: string) =
 	if (typeof process !== 'undefined' && process.env?.T7M_DEBUG !== 'true') return
 	const nameTag = transformerName ? `\x1b[33m[${transformerName}]\x1b[0m` : ''
 	if (data !== undefined) {
-		const jsonData = typeof data === 'string' ? data : JSON.stringify(data, null, 2).substring(0, 300)
+		let jsonData: string
+		if (typeof data === 'string') {
+			jsonData = data
+		} else {
+			try {
+				jsonData = JSON.stringify(data, null, 2).substring(0, 300)
+			} catch {
+				jsonData = String(data)
+			}
+		}
 		console.log(T7M_PREFIX, nameTag, message, jsonData)
 	} else {
 		console.log(T7M_PREFIX, nameTag, message)

--- a/src/lib/semaphore.ts
+++ b/src/lib/semaphore.ts
@@ -12,13 +12,24 @@
  *     urls.map(url => semaphore.run(() => fetch(url)))
  * )
  * ```
+ *
+ * @example Limit queue depth to prevent unbounded growth under sustained load:
+ * ```ts
+ * const semaphore = new Semaphore(5, 100)
+ * // Throws '[T7M] Semaphore queue is full' when 100 tasks are already queued
+ * ```
  */
 class Semaphore {
 	private queue: (() => void)[] = []
 	private active = 0
 
-	constructor(private readonly limit: number) {
+	constructor(
+		private readonly limit: number,
+		private readonly maxQueue?: number
+	) {
 		if (!Number.isInteger(limit) || limit < 1) throw new Error('Semaphore limit must be a positive integer')
+		if (maxQueue !== undefined && (!Number.isInteger(maxQueue) || maxQueue < 1))
+			throw new Error('Semaphore maxQueue must be a positive integer')
 	}
 
 	/**
@@ -27,6 +38,9 @@ class Semaphore {
 	 * @returns The resolved return value of `fn`
 	 */
 	async run<T>(fn: () => T | Promise<T>): Promise<T> {
+		if (this.maxQueue && this.queue.length >= this.maxQueue) {
+			throw new Error('[T7M] Semaphore queue is full')
+		}
 		while (this.active >= this.limit) {
 			await new Promise<void>(resolve => this.queue.push(resolve))
 		}

--- a/tests/abstractTransformer.advanced.test.ts
+++ b/tests/abstractTransformer.advanced.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { describe, expect, it } from 'bun:test'
 import { AbstractTransformer } from '../src/abstractTransformer'
 
@@ -230,7 +227,7 @@ describe('AbstractTransformer - Advanced Tests', () => {
 			}
 
 			// Should not throw when includes aren't used
-			expect(() => {
+			await expect(
 				transformer.transform({
 					input: problematicInput,
 					props: {
@@ -239,7 +236,7 @@ describe('AbstractTransformer - Advanced Tests', () => {
 						enrichmentLevel: 1,
 					},
 				})
-			}).not.toThrow()
+			).resolves.toBeDefined()
 
 			// Should throw when problematic includes are used
 			await expect(

--- a/tests/abstractTransformer.advanced.test.ts
+++ b/tests/abstractTransformer.advanced.test.ts
@@ -13,7 +13,6 @@ interface ComplexInput {
 		secondary?: string
 		nested: {
 			value: number
-			// biome-ignore lint/suspicious/noExplicitAny: Just for this test case
 			metadata?: Record<string, any>
 		}
 	}
@@ -31,7 +30,6 @@ interface ComplexOutput {
 	enriched?: {
 		source: string
 		processed: boolean
-		// biome-ignore lint/suspicious/noExplicitAny: Just for this test case
 		details?: any
 	}
 }
@@ -332,7 +330,6 @@ describe('AbstractTransformer - Advanced Tests', () => {
 			accountType: 'user' | 'admin'
 			details?: {
 				info: string
-				// biome-ignore lint/suspicious/noExplicitAny: Just for this test case
 				extra?: any
 			}
 		}

--- a/tests/abstractTransformer.gaps.test.ts
+++ b/tests/abstractTransformer.gaps.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { describe, expect, it } from 'bun:test'
 import { AbstractTransformer } from '../src/abstractTransformer'
 import { Cache } from '../src/lib/cache'

--- a/tests/abstractTransformer.gaps.test.ts
+++ b/tests/abstractTransformer.gaps.test.ts
@@ -423,9 +423,7 @@ describe('AbstractTransformer - Gap Coverage', () => {
 		it('should skip includes when data() returns null', async () => {
 			let includeWasCalled = false
 
-			// biome-ignore lint/suspicious/noExplicitAny: testing edge case with null return
 			class NullDataTransformer extends AbstractTransformer<Item, any> {
-				// biome-ignore lint/suspicious/noExplicitAny: testing edge case with null return
 				data(_input: Item): any {
 					return null
 				}
@@ -441,7 +439,6 @@ describe('AbstractTransformer - Gap Coverage', () => {
 			const transformer = new NullDataTransformer()
 			const result = await transformer.transform({
 				input: testItem,
-				// biome-ignore lint/suspicious/noExplicitAny: testing edge case
 				includes: ['tags'] as any,
 			})
 
@@ -452,9 +449,7 @@ describe('AbstractTransformer - Gap Coverage', () => {
 		it('should skip includes when data() returns a non-object primitive', async () => {
 			let includeWasCalled = false
 
-			// biome-ignore lint/suspicious/noExplicitAny: testing edge case with primitive return
 			class PrimitiveDataTransformer extends AbstractTransformer<Item, any> {
-				// biome-ignore lint/suspicious/noExplicitAny: testing edge case with primitive return
 				data(_input: Item): any {
 					return 42
 				}
@@ -470,7 +465,6 @@ describe('AbstractTransformer - Gap Coverage', () => {
 			const transformer = new PrimitiveDataTransformer()
 			const result = await transformer.transform({
 				input: testItem,
-				// biome-ignore lint/suspicious/noExplicitAny: testing edge case
 				includes: ['tags'] as any,
 			})
 
@@ -692,7 +686,6 @@ describe('AbstractTransformer - Gap Coverage', () => {
 					childData: async (input: Item, _props: undefined, forwardedIncludes: string[]) => {
 						return this.child.transform({
 							input,
-							// biome-ignore lint/suspicious/noExplicitAny: testing forwarded includes
 							includes: forwardedIncludes as any,
 						})
 					},

--- a/tests/abstractTransformer.test.ts
+++ b/tests/abstractTransformer.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { describe, expect, it } from 'bun:test'
 import { AbstractTransformer } from '../src/abstractTransformer'
 import { Cache } from '../src/lib/cache'

--- a/tests/abstractTransformer.test.ts
+++ b/tests/abstractTransformer.test.ts
@@ -320,6 +320,37 @@ describe('AbstractTransformer', () => {
 			expect(mockFetcher.getCallCount()).toBe(2)
 		})
 
+		it('should clear cache after transform() by default', async () => {
+			const mockFetcher = createMockFetcher()
+
+			class CachedTransformer extends AbstractTransformer<User, PublicUser> {
+				cache = {
+					avatarFetcher: new Cache(mockFetcher.fn),
+				}
+
+				data(input: User): PublicUser {
+					return { name: input.name, email: input.email }
+				}
+
+				includesMap = {
+					avatar: async (input: User) => {
+						const result = await this.cache.avatarFetcher.call(input.id)
+						return result.avatarUrl
+					},
+				}
+			}
+
+			const transformer = new CachedTransformer()
+
+			// First transform
+			await transformer.transform({ input: testUser, includes: ['avatar'] })
+			expect(mockFetcher.getCallCount()).toBe(1)
+
+			// Second transform - cache should be cleared, so fetcher called again
+			await transformer.transform({ input: testUser, includes: ['avatar'] })
+			expect(mockFetcher.getCallCount()).toBe(2)
+		})
+
 		it('should clear cache after _transform by default', async () => {
 			const mockFetcher = createMockFetcher()
 

--- a/tests/abstractTransformer.test.ts
+++ b/tests/abstractTransformer.test.ts
@@ -16,7 +16,6 @@ interface PublicUser {
 	name: string
 	email: string
 	avatar?: string
-	// biome-ignore lint/suspicious/noExplicitAny: Just for this test case
 	metadata?: Record<string, any>
 }
 

--- a/tests/abstractTransformer.type.test.ts
+++ b/tests/abstractTransformer.type.test.ts
@@ -1,6 +1,6 @@
 // Type-level tests for AbstractTransformer
 
-import { AbstractTransformer, IncludesOf, InputOf, OutputOf, PropsOf } from '../src'
+import { AbstractTransformer, type IncludesOf, type InputOf, type OutputOf, type PropsOf } from '../src'
 
 // Helper type for testing type equality
 type Expect<T extends true> = T

--- a/tests/abstractTransformer.type.test.ts
+++ b/tests/abstractTransformer.type.test.ts
@@ -1,5 +1,4 @@
 // Type-level tests for AbstractTransformer
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { AbstractTransformer, IncludesOf, InputOf, OutputOf, PropsOf } from '../src'
 

--- a/tests/cache.edge.test.ts
+++ b/tests/cache.edge.test.ts
@@ -295,6 +295,58 @@ describe('Cache edge cases', () => {
 		})
 	})
 
+	describe('maxSize edge cases (0 and negative)', () => {
+		it('should treat maxSize=0 as unlimited (no eviction)', async () => {
+			let callCount = 0
+			const fn = async (key: string) => {
+				callCount++
+				return `value-${key}`
+			}
+			const cache = new Cache(fn)
+			cache.maxSize = 0
+
+			await cache.call('a')
+			await cache.call('b')
+			await cache.call('c')
+			expect(callCount).toBe(3)
+
+			// All should still be cached
+			await cache.call('a')
+			await cache.call('b')
+			await cache.call('c')
+			expect(callCount).toBe(3)
+		})
+
+		it('should evict immediately with negative maxSize (every insert exceeds limit)', async () => {
+			let callCount = 0
+			const fn = async (key: string) => {
+				callCount++
+				return `value-${key}`
+			}
+			const cache = new Cache(fn)
+			cache.maxSize = -1
+
+			// First call: inserts then immediately evicts (cache.size 1 > -1)
+			await cache.call('a')
+			expect(callCount).toBe(1)
+
+			// Second call to same key: cache miss because entry was evicted
+			await cache.call('a')
+			expect(callCount).toBe(2)
+		})
+
+		it('should still return results with maxSize=0', async () => {
+			const fn = async (n: number) => n * 10
+			const cache = new Cache(fn)
+			cache.maxSize = 0
+
+			const r1 = await cache.call(5)
+			const r2 = await cache.call(5)
+			expect(r1).toBe(50)
+			expect(r2).toBe(50)
+		})
+	})
+
 	describe('clear() on empty cache', () => {
 		it('should not throw when clearing an empty cache', () => {
 			const fn = async () => 'result'

--- a/tests/cache.edge.test.ts
+++ b/tests/cache.edge.test.ts
@@ -66,7 +66,6 @@ describe('Cache edge cases', () => {
 				callCount++
 				return arg
 			}
-			// biome-ignore lint/suspicious/noExplicitAny: testing edge case with mixed argument types
 			const cache = new Cache(fn as (arg: any) => any)
 
 			const r1 = await cache.call(null)
@@ -85,7 +84,6 @@ describe('Cache edge cases', () => {
 				callCount++
 				return arg
 			}
-			// biome-ignore lint/suspicious/noExplicitAny: testing edge case with mixed argument types
 			const cache = new Cache(fn as (arg: any) => any)
 
 			const r1 = await cache.call(null)
@@ -105,7 +103,6 @@ describe('Cache edge cases', () => {
 				callCount++
 				return arg
 			}
-			// biome-ignore lint/suspicious/noExplicitAny: testing edge case with mixed argument types
 			const cache = new Cache(fn as (arg: any) => any)
 
 			const r1 = await cache.call(undefined)

--- a/tests/cache.edge.test.ts
+++ b/tests/cache.edge.test.ts
@@ -226,8 +226,7 @@ describe('Cache edge cases', () => {
 				callCount++
 				return `value-${key}`
 			}
-			const cache = new Cache(fn)
-			cache.maxSize = 3
+			const cache = new Cache(fn, { maxSize: 3 })
 
 			await cache.call('a')
 			await cache.call('b')
@@ -254,8 +253,7 @@ describe('Cache edge cases', () => {
 				callCount++
 				return key * 10
 			}
-			const cache = new Cache(fn)
-			cache.maxSize = 1
+			const cache = new Cache(fn, { maxSize: 1 })
 
 			await cache.call(1)
 			expect(callCount).toBe(1)
@@ -295,60 +293,56 @@ describe('Cache edge cases', () => {
 		})
 	})
 
-	describe('maxSize edge cases (0 and negative)', () => {
-		it('should treat maxSize=0 as unlimited (no eviction)', async () => {
-			let callCount = 0
-			const fn = async (key: string) => {
-				callCount++
-				return `value-${key}`
-			}
-			const cache = new Cache(fn)
-			cache.maxSize = 0
-
-			await cache.call('a')
-			await cache.call('b')
-			await cache.call('c')
-			expect(callCount).toBe(3)
-
-			// All should still be cached
-			await cache.call('a')
-			await cache.call('b')
-			await cache.call('c')
-			expect(callCount).toBe(3)
+	describe('maxSize constructor validation', () => {
+		it('should throw for maxSize = 0', () => {
+			const fn = async (key: string) => key
+			expect(() => new Cache(fn, { maxSize: 0 })).toThrow('positive integer')
 		})
 
-		it('should evict immediately with negative maxSize (every insert exceeds limit)', async () => {
-			let callCount = 0
-			const fn = async (key: string) => {
-				callCount++
-				return `value-${key}`
-			}
-			const cache = new Cache(fn)
-			cache.maxSize = -1
-
-			// First call: inserts then immediately evicts (cache.size 1 > -1)
-			await cache.call('a')
-			expect(callCount).toBe(1)
-
-			// Second call to same key: cache miss because entry was evicted
-			await cache.call('a')
-			expect(callCount).toBe(2)
+		it('should throw for negative maxSize', () => {
+			const fn = async (key: string) => key
+			expect(() => new Cache(fn, { maxSize: -1 })).toThrow('positive integer')
 		})
 
-		it('should still return cached results with maxSize=0', async () => {
-			let callCount = 0
-			const fn = async (n: number) => {
-				callCount++
-				return n * 10
-			}
-			const cache = new Cache(fn)
-			cache.maxSize = 0
+		it('should throw for non-integer maxSize', () => {
+			const fn = async (key: string) => key
+			expect(() => new Cache(fn, { maxSize: 1.5 })).toThrow('positive integer')
+		})
 
-			const r1 = await cache.call(5)
-			const r2 = await cache.call(5)
-			expect(r1).toBe(50)
-			expect(r2).toBe(50)
+		it('should throw for NaN maxSize', () => {
+			const fn = async (key: string) => key
+			expect(() => new Cache(fn, { maxSize: NaN })).toThrow('positive integer')
+		})
+
+		it('should throw for Infinity maxSize', () => {
+			const fn = async (key: string) => key
+			expect(() => new Cache(fn, { maxSize: Infinity })).toThrow('positive integer')
+		})
+
+		it('should accept valid positive integer maxSize', () => {
+			const fn = async (key: string) => key
+			expect(() => new Cache(fn, { maxSize: 1 })).not.toThrow()
+			expect(() => new Cache(fn, { maxSize: 100 })).not.toThrow()
+		})
+
+		it('should work with on and maxSize combined', async () => {
+			let callCount = 0
+			const fn = async (obj: { id: number; ts: number }) => {
+				callCount++
+				return obj.id
+			}
+			const cache = new Cache(fn, { on: ['id'], maxSize: 2 })
+
+			await cache.call({ id: 1, ts: 100 })
+			await cache.call({ id: 1, ts: 200 }) // cache hit (on: ['id'])
 			expect(callCount).toBe(1)
+
+			await cache.call({ id: 2, ts: 300 })
+			await cache.call({ id: 3, ts: 400 }) // evicts id:1 (maxSize: 2)
+			expect(callCount).toBe(3)
+
+			await cache.call({ id: 1, ts: 500 }) // cache miss (evicted)
+			expect(callCount).toBe(4)
 		})
 	})
 

--- a/tests/cache.edge.test.ts
+++ b/tests/cache.edge.test.ts
@@ -335,8 +335,12 @@ describe('Cache edge cases', () => {
 			expect(callCount).toBe(2)
 		})
 
-		it('should still return results with maxSize=0', async () => {
-			const fn = async (n: number) => n * 10
+		it('should still return cached results with maxSize=0', async () => {
+			let callCount = 0
+			const fn = async (n: number) => {
+				callCount++
+				return n * 10
+			}
 			const cache = new Cache(fn)
 			cache.maxSize = 0
 
@@ -344,6 +348,7 @@ describe('Cache edge cases', () => {
 			const r2 = await cache.call(5)
 			expect(r1).toBe(50)
 			expect(r2).toBe(50)
+			expect(callCount).toBe(1)
 		})
 	})
 

--- a/tests/cache.edge.test.ts
+++ b/tests/cache.edge.test.ts
@@ -3,7 +3,7 @@ import { Cache } from '../src/lib/cache'
 
 describe('Cache edge cases', () => {
 	describe('Rejected promise caching', () => {
-		it('should cache a rejected promise and return it on subsequent calls', async () => {
+		it('should share the same rejected promise for concurrent calls before rejection settles', async () => {
 			let callCount = 0
 			const fn = async () => {
 				callCount++
@@ -14,6 +14,7 @@ describe('Cache edge cases', () => {
 			const promise1 = cache.call()
 			const promise2 = cache.call()
 
+			// Before rejection settles, concurrent calls share the same promise
 			expect(promise1).toBe(promise2)
 			expect(callCount).toBe(1)
 
@@ -21,19 +22,23 @@ describe('Cache edge cases', () => {
 			await expect(promise2).rejects.toThrow('fail')
 		})
 
-		it('should not re-execute function after rejection', async () => {
+		it('should auto-evict rejected promise and retry on next call', async () => {
 			let callCount = 0
-			const fn = async (key: string) => {
+			const fn = async (_key: string) => {
 				callCount++
-				throw new Error('rejected')
+				if (callCount <= 1) throw new Error('transient')
+				return 'recovered'
 			}
 			const cache = new Cache(fn)
 
-			await expect(cache.call('a')).rejects.toThrow('rejected')
-			await expect(cache.call('a')).rejects.toThrow('rejected')
-			await expect(cache.call('a')).rejects.toThrow('rejected')
-
+			// First call fails
+			await expect(cache.call('a')).rejects.toThrow('transient')
 			expect(callCount).toBe(1)
+
+			// After rejection settles, the entry is evicted — next call retries
+			const result = await cache.call('a')
+			expect(result).toBe('recovered')
+			expect(callCount).toBe(2)
 		})
 	})
 
@@ -116,8 +121,8 @@ describe('Cache edge cases', () => {
 		})
 	})
 
-	describe('Nested object serialization collision', () => {
-		it('should collide objects with different nested values due to [object Object] serialization', async () => {
+	describe('Nested object serialization', () => {
+		it('should NOT collide objects with different nested values thanks to JSON serialization', async () => {
 			let callCount = 0
 			const fn = async (obj: { id: number; data: object }) => {
 				callCount++
@@ -131,10 +136,162 @@ describe('Cache edge cases', () => {
 			const r1 = await cache.call(obj1)
 			const r2 = await cache.call(obj2)
 
-			// Both nested objects serialize to "[object Object]", so cache keys collide
+			// JSON.stringify properly serializes nested objects, so cache keys do NOT collide
 			expect(r1).toBe(obj1)
-			expect(r2).toBe(obj1) // returns cached obj1, not obj2
+			expect(r2).toBe(obj2)
+			expect(callCount).toBe(2)
+		})
+	})
+
+	describe('Primitive type-aware cache keys', () => {
+		it('should NOT collide number 42 and string "42"', async () => {
+			let callCount = 0
+			const fn = async (arg: unknown) => {
+				callCount++
+				return arg
+			}
+			const cache = new Cache(fn as (arg: any) => any)
+
+			const r1 = await cache.call(42)
+			const r2 = await cache.call('42')
+
+			expect(r1).toBe(42)
+			expect(r2).toBe('42')
+			expect(callCount).toBe(2)
+		})
+
+		it('should NOT collide boolean true and string "true"', async () => {
+			let callCount = 0
+			const fn = async (arg: unknown) => {
+				callCount++
+				return arg
+			}
+			const cache = new Cache(fn as (arg: any) => any)
+
+			const r1 = await cache.call(true)
+			const r2 = await cache.call('true')
+
+			expect(r1).toBe(true)
+			expect(r2).toBe('true')
+			expect(callCount).toBe(2)
+		})
+	})
+
+	describe('Object delimiter injection', () => {
+		it('should NOT collide objects with delimiter-like values', async () => {
+			let callCount = 0
+			const fn = async (obj: Record<string, unknown>) => {
+				callCount++
+				return obj
+			}
+			const cache = new Cache(fn)
+
+			const obj1 = { a: '1|b:2' }
+			const obj2 = { a: '1', b: '2' }
+
+			const r1 = await cache.call(obj1)
+			const r2 = await cache.call(obj2)
+
+			expect(r1).toBe(obj1)
+			expect(r2).toBe(obj2)
+			expect(callCount).toBe(2)
+		})
+	})
+
+	describe('Nested object distinction', () => {
+		it('should NOT collide objects with different nested data', async () => {
+			let callCount = 0
+			const fn = async (obj: { data: { x: number } }) => {
+				callCount++
+				return obj
+			}
+			const cache = new Cache(fn)
+
+			const obj1 = { data: { x: 1 } }
+			const obj2 = { data: { x: 2 } }
+
+			const r1 = await cache.call(obj1)
+			const r2 = await cache.call(obj2)
+
+			expect(r1).toBe(obj1)
+			expect(r2).toBe(obj2)
+			expect(callCount).toBe(2)
+		})
+	})
+
+	describe('maxSize eviction', () => {
+		it('should evict oldest entry when cache exceeds maxSize', async () => {
+			let callCount = 0
+			const fn = async (key: string) => {
+				callCount++
+				return `value-${key}`
+			}
+			const cache = new Cache(fn)
+			cache.maxSize = 3
+
+			await cache.call('a')
+			await cache.call('b')
+			await cache.call('c')
+			expect(callCount).toBe(3)
+
+			// Adding 4th entry should evict 'a' (oldest)
+			await cache.call('d')
+			expect(callCount).toBe(4)
+
+			// 'a' was evicted, so calling it again re-executes the function
+			await cache.call('a')
+			expect(callCount).toBe(5)
+
+			// 'c' and 'd' should still be cached
+			await cache.call('c')
+			await cache.call('d')
+			expect(callCount).toBe(5)
+		})
+
+		it('should work correctly with maxSize = 1', async () => {
+			let callCount = 0
+			const fn = async (key: number) => {
+				callCount++
+				return key * 10
+			}
+			const cache = new Cache(fn)
+			cache.maxSize = 1
+
+			await cache.call(1)
 			expect(callCount).toBe(1)
+
+			// Same key is still cached
+			await cache.call(1)
+			expect(callCount).toBe(1)
+
+			// New key evicts old
+			await cache.call(2)
+			expect(callCount).toBe(2)
+
+			// Old key is gone
+			await cache.call(1)
+			expect(callCount).toBe(3)
+		})
+
+		it('should not limit cache size when maxSize is not set', async () => {
+			let callCount = 0
+			const fn = async (key: number) => {
+				callCount++
+				return key
+			}
+			const cache = new Cache(fn)
+
+			// Add many entries without maxSize
+			for (let i = 0; i < 100; i++) {
+				await cache.call(i)
+			}
+			expect(callCount).toBe(100)
+
+			// All should still be cached
+			for (let i = 0; i < 100; i++) {
+				await cache.call(i)
+			}
+			expect(callCount).toBe(100)
 		})
 	})
 

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -210,7 +210,7 @@ describe('Cache', () => {
 	describe('Object arguments with on parameter', () => {
 		it('should use only specified keys with on parameter', async () => {
 			const mock = createMockFn((obj: { id: number; name: string; timestamp: number }) => obj.id)
-			const cache = new Cache(mock.fn, 'id')
+			const cache = new Cache(mock.fn, { on: ['id'] })
 
 			const result1 = await cache.call({ id: 1, name: 'test', timestamp: 100 })
 			const result2 = await cache.call({ id: 1, name: 'test', timestamp: 200 })
@@ -222,7 +222,7 @@ describe('Cache', () => {
 
 		it('should ignore non-specified keys with on parameter', async () => {
 			const mock = createMockFn((obj: { id: number; name: string; extra: string }) => `${obj.id}-${obj.name}`)
-			const cache = new Cache(mock.fn, 'id', 'name')
+			const cache = new Cache(mock.fn, { on: ['id', 'name'] })
 
 			await cache.call({ id: 1, name: 'test', extra: 'a' })
 			await cache.call({ id: 1, name: 'test', extra: 'b' })
@@ -298,7 +298,7 @@ describe('Cache', () => {
 
 		it('should be fast for object lookups', async () => {
 			const mock = createMockFn((obj: { id: number; name: string }) => obj.id)
-			const cache = new Cache(mock.fn, 'id', 'name')
+			const cache = new Cache(mock.fn, { on: ['id', 'name'] })
 			const iterations = 10000
 
 			// Warm up cache

--- a/tests/elysia.test.ts
+++ b/tests/elysia.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn } from 'bun:test'
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from 'bun:test'
 import { Elysia } from 'elysia'
 import { AbstractTransformer, Cache } from '../src'
 import { t7mPlugin } from '../src/elysia'
@@ -299,6 +299,13 @@ describe('t7mPlugin (Elysia)', () => {
 	// 8. debug option
 	// -------------------------------------------------------
 	describe('debug option', () => {
+		beforeAll(() => {
+			process.env.T7M_DEBUG = 'true'
+		})
+		afterAll(() => {
+			delete process.env.T7M_DEBUG
+		})
+
 		it('should call console.log when debug is true for transform()', async () => {
 			const transformer = new UserTransformer()
 			const app = new Elysia()

--- a/tests/hono.test.ts
+++ b/tests/hono.test.ts
@@ -398,6 +398,48 @@ describe('t7mMiddleware', () => {
 	})
 
 	// -------------------------------------------------------
+	// 8b. debug gate without T7M_DEBUG env var
+	// -------------------------------------------------------
+	describe('debug gate without T7M_DEBUG env var', () => {
+		it('should not call console.log when debug is true but T7M_DEBUG is not set', async () => {
+			delete process.env.T7M_DEBUG
+
+			const transformer = new UserTransformer()
+			const app = new Hono()
+			app.use('*', t7mMiddleware)
+			app.get('/user', async c => {
+				return c.transform(testUser, transformer, { debug: true })
+			})
+
+			await app.request('/user')
+
+			expect(consoleSpy).not.toHaveBeenCalled()
+		})
+
+		it('should still transform correctly when debug is true but T7M_DEBUG is not set', async () => {
+			delete process.env.T7M_DEBUG
+
+			const transformer = new UserTransformer()
+			const app = new Hono()
+			app.use('*', t7mMiddleware)
+			app.get('/user', async c => {
+				return c.transform(testUser, transformer, { debug: true, includes: ['avatar'] })
+			})
+
+			const res = await app.request('/user')
+
+			expect(res.status).toBe(200)
+			const body = await res.json()
+			expect(body).toEqual({
+				name: 'Alice',
+				email: 'alice@example.com',
+				avatar: 'https://avatar.example.com/1',
+			})
+			expect(consoleSpy).not.toHaveBeenCalled()
+		})
+	})
+
+	// -------------------------------------------------------
 	// 9. Props forwarding
 	// -------------------------------------------------------
 	describe('props forwarding', () => {

--- a/tests/hono.test.ts
+++ b/tests/hono.test.ts
@@ -401,6 +401,10 @@ describe('t7mMiddleware', () => {
 	// 8b. debug gate without T7M_DEBUG env var
 	// -------------------------------------------------------
 	describe('debug gate without T7M_DEBUG env var', () => {
+		afterAll(() => {
+			delete process.env.T7M_DEBUG
+		})
+
 		it('should not call console.log when debug is true but T7M_DEBUG is not set', async () => {
 			delete process.env.T7M_DEBUG
 

--- a/tests/hono.test.ts
+++ b/tests/hono.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, spyOn } from 'bun:test'
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from 'bun:test'
 import { Hono } from 'hono'
 import { AbstractTransformer } from '../src'
 import { t7mMiddleware } from '../src/hono'
@@ -327,6 +327,13 @@ describe('t7mMiddleware', () => {
 	// 8. debug option
 	// -------------------------------------------------------
 	describe('debug option', () => {
+		beforeAll(() => {
+			process.env.T7M_DEBUG = 'true'
+		})
+		afterAll(() => {
+			delete process.env.T7M_DEBUG
+		})
+
 		it('should call console.log when debug is true for c.transform()', async () => {
 			const transformer = new UserTransformer()
 			const app = new Hono()

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -1,42 +1,40 @@
-import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from 'bun:test'
 import { log } from '../src/lib/log'
 
 describe('log', () => {
 	const originalEnv = process.env.T7M_DEBUG
+	const consoleSpy = spyOn(console, 'log')
 
 	beforeAll(() => {
 		process.env.T7M_DEBUG = 'true'
 	})
+	afterEach(() => {
+		consoleSpy.mockClear()
+	})
 	afterAll(() => {
 		if (originalEnv !== undefined) process.env.T7M_DEBUG = originalEnv
 		else delete process.env.T7M_DEBUG
+		consoleSpy.mockRestore()
 	})
 
-	it('should not throw on circular references', () => {
+	it('should not throw on circular references and use String() fallback', () => {
 		const circular: Record<string, unknown> = { name: 'test' }
 		circular.self = circular
 
-		const consoleSpy = mock(() => {})
-		const original = console.log
-		console.log = consoleSpy
-
 		expect(() => log('Circular:', circular)).not.toThrow()
 		expect(consoleSpy).toHaveBeenCalled()
-
-		console.log = original
+		// Verify the catch branch produced the String() fallback
+		const args = consoleSpy.mock.calls[0]
+		const output = args.join(' ')
+		expect(output).toContain('[object Object]')
 	})
 
-	it('should handle normal objects', () => {
-		const consoleSpy = mock(() => {})
-		const original = console.log
-		console.log = consoleSpy
-
+	it('should handle normal objects with JSON serialization', () => {
 		log('Normal:', { key: 'value' })
 		expect(consoleSpy).toHaveBeenCalled()
 		const args = consoleSpy.mock.calls[0]
 		const output = args.join(' ')
-		expect(output).toContain('value')
-
-		console.log = original
+		expect(output).toContain('"key"')
+		expect(output).toContain('"value"')
 	})
 })

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { log } from '../src/lib/log'
+
+describe('log', () => {
+	const originalEnv = process.env.T7M_DEBUG
+
+	beforeAll(() => {
+		process.env.T7M_DEBUG = 'true'
+	})
+	afterAll(() => {
+		if (originalEnv !== undefined) process.env.T7M_DEBUG = originalEnv
+		else delete process.env.T7M_DEBUG
+	})
+
+	it('should not throw on circular references', () => {
+		const circular: Record<string, unknown> = { name: 'test' }
+		circular.self = circular
+
+		const consoleSpy = mock(() => {})
+		const original = console.log
+		console.log = consoleSpy
+
+		expect(() => log('Circular:', circular)).not.toThrow()
+		expect(consoleSpy).toHaveBeenCalled()
+
+		console.log = original
+	})
+
+	it('should handle normal objects', () => {
+		const consoleSpy = mock(() => {})
+		const original = console.log
+		console.log = consoleSpy
+
+		log('Normal:', { key: 'value' })
+		expect(consoleSpy).toHaveBeenCalled()
+		const args = consoleSpy.mock.calls[0]
+		const output = args.join(' ')
+		expect(output).toContain('value')
+
+		console.log = original
+	})
+})

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'bun:test'
+import { AbstractTransformer } from '../src/abstractTransformer'
+
+interface UserInput {
+	id: number
+	name: string
+	secret: string
+}
+
+interface UserOutput {
+	name: string
+	avatar?: string
+}
+
+class SimpleTransformer extends AbstractTransformer<UserInput, UserOutput> {
+	data(input: UserInput): UserOutput {
+		return {
+			name: input.name,
+		}
+	}
+
+	includesMap = {
+		avatar: (input: UserInput) => `https://avatar.com/${input.id}`,
+	}
+}
+
+describe('Prototype property injection', () => {
+	const input: UserInput = { id: 1, name: 'Alice', secret: 'hunter2' }
+
+	it('should ignore ?include=constructor and not leak raw input', async () => {
+		const transformer = new SimpleTransformer()
+		const result = await transformer.transform({
+			input,
+			unsafeIncludes: ['constructor'],
+		})
+
+		expect(result).toEqual({ name: 'Alice' })
+		// constructor must not be an own property on the result
+		expect(Object.hasOwn(result, 'constructor')).toBe(false)
+		expect(JSON.stringify(result)).not.toContain('hunter2')
+	})
+
+	it('should ignore ?include=toString and not corrupt output', async () => {
+		const transformer = new SimpleTransformer()
+		const result = await transformer.transform({
+			input,
+			unsafeIncludes: ['toString'],
+		})
+
+		expect(result).toEqual({ name: 'Alice' })
+		expect(typeof result.toString).toBe('function')
+		expect(result.toString()).toBe('[object Object]')
+	})
+
+	it('should ignore ?include=__proto__ without error or pollution', async () => {
+		const transformer = new SimpleTransformer()
+		const result = await transformer.transform({
+			input,
+			unsafeIncludes: ['__proto__'],
+		})
+
+		expect(result).toEqual({ name: 'Alice' })
+		expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+	})
+
+	it('should ignore ?include=hasOwnProperty and not corrupt output', async () => {
+		const transformer = new SimpleTransformer()
+		const result = await transformer.transform({
+			input,
+			unsafeIncludes: ['hasOwnProperty'],
+		})
+
+		expect(result).toEqual({ name: 'Alice' })
+		expect(typeof result.hasOwnProperty).toBe('function')
+	})
+
+	it('should ignore ?include=valueOf and not corrupt output', async () => {
+		const transformer = new SimpleTransformer()
+		const result = await transformer.transform({
+			input,
+			unsafeIncludes: ['valueOf'],
+		})
+
+		expect(result).toEqual({ name: 'Alice' })
+		expect(typeof result.valueOf).toBe('function')
+		expect(result.valueOf()).toEqual({ name: 'Alice' })
+	})
+
+	it('should still resolve legitimate includes alongside prototype names', async () => {
+		const transformer = new SimpleTransformer()
+		const result = await transformer.transform({
+			input,
+			includes: ['avatar'],
+			unsafeIncludes: ['constructor', '__proto__'],
+		})
+
+		expect(result).toEqual({ name: 'Alice', avatar: 'https://avatar.com/1' })
+		expect(JSON.stringify(result)).not.toContain('hunter2')
+	})
+})

--- a/tests/semaphore.test.ts
+++ b/tests/semaphore.test.ts
@@ -67,4 +67,50 @@ describe('Semaphore', () => {
 		const result = await semaphore.run(async () => 42)
 		expect(result).toBe(42)
 	})
+
+	it('should throw when queue exceeds maxQueue', async () => {
+		const semaphore = new Semaphore(1, 5)
+		let release!: () => void
+		const barrier = new Promise<void>(r => {
+			release = r
+		})
+
+		// Fill the active slot
+		const blocker = semaphore.run(() => barrier)
+
+		// Queue 5 tasks (maxQueue: 5) — should succeed
+		const queued = Array.from({ length: 5 }, (_, i) => semaphore.run(async () => i))
+
+		// 6th queued task should throw
+		expect(() => semaphore.run(async () => 'overflow')).toThrow('[T7M] Semaphore queue is full')
+
+		// Unblock and let everything finish
+		release()
+		await blocker
+		await Promise.all(queued)
+	})
+
+	it('should allow unlimited queue when maxQueue is not set', async () => {
+		const semaphore = new Semaphore(1)
+		let release!: () => void
+		const barrier = new Promise<void>(r => {
+			release = r
+		})
+
+		const blocker = semaphore.run(() => barrier)
+
+		// Queue many tasks — should not throw
+		const queued = Array.from({ length: 100 }, (_, i) => semaphore.run(async () => i))
+
+		release()
+		await blocker
+		const results = await Promise.all(queued)
+		expect(results).toHaveLength(100)
+	})
+
+	it('should throw for invalid maxQueue values', () => {
+		expect(() => new Semaphore(1, 0)).toThrow('Semaphore maxQueue must be a positive integer')
+		expect(() => new Semaphore(1, -1)).toThrow('Semaphore maxQueue must be a positive integer')
+		expect(() => new Semaphore(1, 1.5)).toThrow('Semaphore maxQueue must be a positive integer')
+	})
 })

--- a/tests/subTransformer.deep.test.ts
+++ b/tests/subTransformer.deep.test.ts
@@ -585,6 +585,47 @@ describe('SubTransformer Deep Tests', () => {
 			expect(clearSpy).toHaveBeenCalledTimes(1)
 		})
 
+		it('should still decrement activeTransforms and clear cache when one _transform rejects', async () => {
+			let resolveGood!: () => void
+			const deferredGood = new Promise<void>(r => {
+				resolveGood = r
+			})
+
+			class FailingTransformer extends AbstractTransformer<number, { val: number; slow?: string }> {
+				data(input: number) {
+					return { val: input }
+				}
+
+				includesMap = {
+					slow: async (input: number) => {
+						if (input === 1) throw new Error('include failed')
+						await deferredGood
+						return `slow-${input}`
+					},
+				}
+			}
+
+			const transformer = new FailingTransformer()
+			const clearSpy = spyOn(transformer, 'clearCache')
+
+			// Start two concurrent _transform calls — input 1 will reject
+			const p1 = transformer._transform({ input: 1, props: undefined, unsafeIncludes: ['slow'] })
+			const p2 = transformer._transform({ input: 2, props: undefined, unsafeIncludes: ['slow'] })
+
+			// p1 rejects immediately
+			await expect(p1).rejects.toThrow('include failed')
+
+			// Cache should NOT have been cleared yet (p2 still active)
+			expect(clearSpy).not.toHaveBeenCalled()
+
+			// Complete p2
+			resolveGood()
+			await p2
+
+			// Now cache should have been cleared (activeTransforms reached 0)
+			expect(clearSpy).toHaveBeenCalledTimes(1)
+		})
+
 		it('should produce correct results from concurrent transforms', async () => {
 			let resolve1!: () => void
 			let resolve2!: () => void

--- a/tests/subTransformer.deep.test.ts
+++ b/tests/subTransformer.deep.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { AbstractTransformer, AnyAbstractTransformer } from '../src/abstractTransformer'
+import { AbstractTransformer } from '../src/abstractTransformer'
 import { Cache } from '../src/lib/cache'
 
 // ─── Test Data Types ────────────────────────────────────────────────

--- a/tests/subTransformer.deep.test.ts
+++ b/tests/subTransformer.deep.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, spyOn } from 'bun:test'
 import { AbstractTransformer } from '../src/abstractTransformer'
 import { Cache } from '../src/lib/cache'
 
@@ -484,6 +484,143 @@ describe('SubTransformer Deep Tests', () => {
 			expect(results[0]!.author!.name).toBe('Alice')
 			// Orphan post has no author
 			expect(results[1]!.author).toBeUndefined()
+		})
+	})
+
+	// ─── 4. Concurrent _transform + _transformMany (activeTransforms counter) ───
+	describe('Concurrent _transform + _transformMany', () => {
+		it('should not clear cache until all concurrent _transform calls complete', async () => {
+			let resolve1!: () => void
+			let resolve2!: () => void
+			const deferred1 = new Promise<void>(r => {
+				resolve1 = r
+			})
+			const deferred2 = new Promise<void>(r => {
+				resolve2 = r
+			})
+
+			class SlowTransformer extends AbstractTransformer<number, { val: number; slow?: string }> {
+				data(input: number) {
+					return { val: input }
+				}
+
+				includesMap = {
+					slow: async (input: number) => {
+						if (input === 1) await deferred1
+						else await deferred2
+						return `slow-${input}`
+					},
+				}
+			}
+
+			const transformer = new SlowTransformer()
+			const clearSpy = spyOn(transformer, 'clearCache')
+
+			// Start two concurrent _transform calls
+			const p1 = transformer._transform({ input: 1, props: undefined, unsafeIncludes: ['slow'] })
+			const p2 = transformer._transform({ input: 2, props: undefined, unsafeIncludes: ['slow'] })
+
+			// Complete first transform
+			resolve1()
+			await p1
+
+			// Cache should NOT have been cleared yet (activeTransforms still > 0)
+			expect(clearSpy).not.toHaveBeenCalled()
+
+			// Complete second transform
+			resolve2()
+			await p2
+
+			// Now cache should have been cleared (activeTransforms reached 0)
+			expect(clearSpy).toHaveBeenCalledTimes(1)
+		})
+
+		it('should not clear cache during concurrent _transform and _transformMany', async () => {
+			let resolveSingle!: () => void
+			let resolveMany!: () => void
+			const deferredSingle = new Promise<void>(r => {
+				resolveSingle = r
+			})
+			const deferredMany = new Promise<void>(r => {
+				resolveMany = r
+			})
+
+			class SlowTransformer extends AbstractTransformer<number, { val: number; slow?: string }> {
+				data(input: number) {
+					return { val: input }
+				}
+
+				includesMap = {
+					slow: async (input: number) => {
+						if (input === 1) await deferredSingle
+						else await deferredMany
+						return `slow-${input}`
+					},
+				}
+			}
+
+			const transformer = new SlowTransformer()
+			const clearSpy = spyOn(transformer, 'clearCache')
+
+			// Start _transform and _transformMany concurrently
+			const pSingle = transformer._transform({ input: 1, props: undefined, unsafeIncludes: ['slow'] })
+			const pMany = transformer._transformMany({
+				inputs: [2, 3],
+				props: undefined,
+				unsafeIncludes: ['slow'],
+			})
+
+			// Complete single transform first
+			resolveSingle()
+			await pSingle
+
+			// Cache should NOT have been cleared yet (_transformMany still active)
+			expect(clearSpy).not.toHaveBeenCalled()
+
+			// Complete many transform
+			resolveMany()
+			await pMany
+
+			// Now cache should have been cleared (all transforms done)
+			expect(clearSpy).toHaveBeenCalledTimes(1)
+		})
+
+		it('should produce correct results from concurrent transforms', async () => {
+			let resolve1!: () => void
+			let resolve2!: () => void
+			const deferred1 = new Promise<void>(r => {
+				resolve1 = r
+			})
+			const deferred2 = new Promise<void>(r => {
+				resolve2 = r
+			})
+
+			class SlowTransformer extends AbstractTransformer<number, { val: number; slow?: string }> {
+				data(input: number) {
+					return { val: input }
+				}
+
+				includesMap = {
+					slow: async (input: number) => {
+						if (input === 1) await deferred1
+						else await deferred2
+						return `slow-${input}`
+					},
+				}
+			}
+
+			const transformer = new SlowTransformer()
+
+			const p1 = transformer._transform({ input: 1, props: undefined, unsafeIncludes: ['slow'] })
+			const p2 = transformer._transform({ input: 2, props: undefined, unsafeIncludes: ['slow'] })
+
+			// Resolve in reverse order
+			resolve2()
+			resolve1()
+
+			const [r1, r2] = await Promise.all([p1, p2])
+			expect(r1).toEqual({ val: 1, slow: 'slow-1' })
+			expect(r2).toEqual({ val: 2, slow: 'slow-2' })
 		})
 	})
 })

--- a/tests/subTransformer.test.ts
+++ b/tests/subTransformer.test.ts
@@ -854,11 +854,10 @@ describe('SubTransformer Tests', () => {
 			expect(clearLog.indexOf('child:clear')).toBeGreaterThan(clearLog.indexOf('child:data'))
 		})
 
-		it('should restore child clearCacheOnTransform after parent completes', async () => {
+		it('should not mutate child clearCacheOnTransform during parent transform', async () => {
 			resetClearLog()
 			resetFetchCounts()
 
-			// Child with clearCacheOnTransform: true (default would be true, but we set explicitly)
 			class RestoredChildTransformer extends AbstractTransformer<Author, AuthorOutput> {
 				constructor() {
 					super({ clearCacheOnTransform: true })
@@ -906,7 +905,7 @@ describe('SubTransformer Tests', () => {
 				includes: ['author'],
 			})
 
-			// After transform completes, child's clearCacheOnTransform should be restored to true
+			// clearCacheOnTransform is readonly — it should remain true throughout
 			expect(getChildClearCache()).toBe(true)
 		})
 

--- a/tests/subTransformer.test.ts
+++ b/tests/subTransformer.test.ts
@@ -631,7 +631,6 @@ describe('SubTransformer Tests', () => {
 
 			// Child cache should also be cleared
 			// Call child cache again - if cleared, this will be a fresh call
-			// biome-ignore lint/suspicious/noExplicitAny: accessing private cache internals for testing
 			const childCacheSizeBefore = (parent.childTransformer.cache.data as any).cache?.size ?? 0
 			expect(childCacheSizeBefore).toBe(0) // Cache was cleared
 		})
@@ -909,6 +908,78 @@ describe('SubTransformer Tests', () => {
 
 			// After transform completes, child's clearCacheOnTransform should be restored to true
 			expect(getChildClearCache()).toBe(true)
+		})
+
+		it('should not clear cache mid-flight when two _transform calls overlap', async () => {
+			resetFetchCounts()
+
+			class ConcurrentChildTransformer extends AbstractTransformer<Author, AuthorOutput> {
+				constructor() {
+					super({ clearCacheOnTransform: false })
+				}
+
+				cache = {
+					data: new Cache(async (id: number) => ({ fetched: true, id })),
+				}
+
+				data(input: Author): AuthorOutput {
+					return { id: input.id, name: input.name }
+				}
+			}
+
+			class ConcurrentParentTransformer extends AbstractTransformer<Post, PostOutput> {
+				childTransformer = new ConcurrentChildTransformer()
+
+				constructor() {
+					super({ clearCacheOnTransform: true })
+					this.transformers = { child: this.childTransformer }
+				}
+
+				cache = {
+					author: new Cache(fetchAuthorById),
+				}
+
+				data(input: Post): PostOutput {
+					return { id: input.id, title: input.title }
+				}
+
+				includesMap = {
+					author: async (input: Post) => {
+						const author = await this.cache.author.call(input.authorId)
+						if (!author) return undefined
+						return this.childTransformer.transform({ input: author })
+					},
+				}
+			}
+
+			const transformer = new ConcurrentParentTransformer()
+
+			// Pre-populate cache
+			await transformer.cache.author.call(1)
+			expect(authorFetchCount).toBe(1)
+
+			// Fire two overlapping _transform calls on the same instance
+			const callA = transformer._transform({
+				input: posts[0]!,
+				props: undefined,
+				includes: ['author'],
+			})
+
+			const callB = transformer._transform({
+				input: posts[1]!,
+				props: undefined,
+				includes: ['author'],
+			})
+
+			const [resultA, resultB] = await Promise.all([callA, callB])
+
+			expect(resultA.id).toBe(1)
+			expect(resultB.id).toBe(2)
+			// Both posts share authorId=1 — the cache should have been available
+			// throughout both transforms, only cleared after the last one finishes.
+			// Without the counter fix, Call A finishing first would clear the cache
+			// while Call B is still running.
+			expect(authorFetchCount).toBe(1)
 		})
 	})
 })

--- a/tests/subTransformer.test.ts
+++ b/tests/subTransformer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { AbstractTransformer, AnyAbstractTransformer } from '../src/abstractTransformer'
+import { AbstractTransformer } from '../src/abstractTransformer'
 import { Cache } from '../src/lib/cache'
 
 // Test types

--- a/tests/type.gaps.test.ts
+++ b/tests/type.gaps.test.ts
@@ -1,7 +1,6 @@
 // Type-level gap tests for AbstractTransformer
 // These are compile-time only assertions - no runtime tests.
 
-import type { IncludesOf, InputOf, OutputOf, PropsOf } from '../src'
 import { AbstractTransformer, type IncludeFunction } from '../src/abstractTransformer'
 
 // Helper types for testing type equality

--- a/tests/type.gaps.test.ts
+++ b/tests/type.gaps.test.ts
@@ -1,6 +1,5 @@
 // Type-level gap tests for AbstractTransformer
 // These are compile-time only assertions - no runtime tests.
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { IncludesOf, InputOf, OutputOf, PropsOf } from '../src'
 import { AbstractTransformer, type IncludeFunction } from '../src/abstractTransformer'


### PR DESCRIPTION
## Summary
- Prevent prototype injection via `Object.hasOwn()` in include parameter validation
- Harden cache with key sanitization, `maxSize` eviction, and rejected-promise cleanup
- Add semaphore `maxQueue` for backpressure control
- Replace fragile `disable/restore` cache mechanism with `activeTransforms` counter for correct concurrent behavior
- Gate debug logging behind `T7M_DEBUG` env var with `JSON.stringify` try/catch safety
- Trim whitespace from include query params in Hono and Elysia middleware
- Improve Hono middleware type safety (arrow functions, `type` imports)
- Pin CI actions to commit SHAs, add `permissions: contents: read`, dependabot config
- Harden publish workflow with lint, typecheck, and branch verification steps
- Add comprehensive test suites: security, cache edge cases, semaphore, concurrent transforms
- Add `SECURITY.md` vulnerability disclosure policy
- Clean up dead lint suppressions, fix biome config, update `CLAUDE.md`

## Test plan
- [x] All 213 tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [x] Type check passes (`bun run typecheck`)
- [x] Build succeeds (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)